### PR TITLE
Entropic regularization for LR-GW

### DIFF
--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -122,8 +122,7 @@ class GromovWasserstein:
   """A Gromov Wasserstein solver."""
 
   def __init__(self,
-               epsilon: Optional[Union[epsilon_scheduler.Epsilon,
-                                       float]] = None,
+               epsilon: Optional[float] = None,
                rank: int = -1,
                linear_ot_solver: Any = None,
                min_iterations: int = 5,
@@ -132,24 +131,37 @@ class GromovWasserstein:
                jit: bool = True,
                store_inner_errors: bool = False,
                **kwargs):
-    self.epsilon = epsilon
-    self.rank = rank
     default_epsilon = 1.0
-    if epsilon is None and rank is None:
-      self.epsilon = default_epsilon
+    # Set epsilon value to default if needed, but keep track of whether None was
+    # passed to handle the case where a linear_ot_solver is passed or not.
+    self.epsilon = epsilon if epsilon is not None else default_epsilon
+    self.rank = rank
     self.linear_ot_solver = linear_ot_solver
+    if self.linear_ot_solver is None:
+      # Detect if user requests low-rank solver. In that case the
+      # default_epsilon makes little sense, since it was designed for GW.
+      if self.is_low_rank:
+        if epsilon is None:
+          # Use default entropic regularization in LRSinkhorn if None was passed
+          self.linear_ot_solver = sinkhorn_lr.LRSinkhorn(
+            rank=self.rank, **kwargs)
+        else:
+          # If epsilon is passed, use it to replace the default LRSinkhorn value
+          self.linear_ot_solver = sinkhorn_lr.LRSinkhorn(
+            rank=self.rank,
+            epsilon=self.epsilon, **kwargs)
+      else:
+        # When using Entropic GW, epsilon is not handled inside Sinkhorn, 
+        # but rather added back to the Geometry object reinstantiated 
+        # when linearizing the problem. Therefore no need to pass it to solver.
+        self.linear_ot_solver = sinkhorn.Sinkhorn(**kwargs)
+
     self.min_iterations = min_iterations
     self.max_iterations = max_iterations
     self.threshold = threshold
     self.jit = jit
     self.store_inner_errors = store_inner_errors
     self._kwargs = kwargs
-
-    if self.linear_ot_solver is None:
-      if self.is_low_rank:
-        self.linear_ot_solver = sinkhorn_lr.LRSinkhorn(rank=rank, **kwargs)
-      else:
-        self.linear_ot_solver = sinkhorn.Sinkhorn(**kwargs)
 
   @property
   def is_low_rank(self):
@@ -303,11 +315,12 @@ def iterations(solver: GromovWasserstein,
 
 def make(
     epsilon: Union[epsilon_scheduler.Epsilon, float] = 1.,
+    rank: int = -1,
     max_iterations: int = 50,
     jit: bool = False,
     warm_start: bool = True,
     store_inner_errors: bool = False,
-    sinkhorn_kwargs: Optional[Dict[str, Any]] = None,
+    linear_ot_solver_kwargs: Optional[Dict[str, Any]] = None,
     threshold: float = 1e-2,
     min_iterations: int = 1,
     **kwargs) -> GromovWasserstein:
@@ -315,14 +328,15 @@ def make(
 
   Args:
     epsilon: a regularization parameter or a epsilon_scheduler.Epsilon object.
+    rank: integer used to constrain the rank of GW solutions if >0.
     max_iterations: int32, the maximum number of outer iterations for
       Gromov Wasserstein.
     jit: bool, if True, jits the function.
     warm_start: deprecated.
     store_inner_errors: whether or not to return all the errors of the inner
       Sinkhorn iterations.
-    sinkhorn_kwargs: Optionally a dictionary containing the keywords arguments
-     for calls to the sinkhorn function.
+    linear_ot_solver_kwargs: Optionally a dictionary containing the keywords 
+      arguments for the linear OT solver (e.g. sinkhorn)
     threshold: threshold (progress between two iterate costs) used to stop GW.
     min_iterations: see fixed_point_loop.
     **kwargs: additional kwargs for epsilon.
@@ -331,10 +345,16 @@ def make(
     A GromovWasserstein solver.
   """
   del warm_start
-  sinkhorn_kwargs = {} if sinkhorn_kwargs is None else sinkhorn_kwargs
-  sink = sinkhorn.make(**sinkhorn_kwargs)
+  if linear_ot_solver_kwargs is None:
+    linear_ot_solver_kwargs = {}
+
+  if rank == -1:
+    sink = sinkhorn.make(**linear_ot_solver_kwargs)
+  elif rank > 0:
+    sink = sinkhorn_lr.make(**linear_ot_solver_kwargs)
+
   return GromovWasserstein(
-      epsilon, max_iterations=max_iterations,
+      epsilon, rank, max_iterations=max_iterations,
       jit=jit, linear_ot_solver=sink, threshold=threshold,
       store_inner_errors=store_inner_errors,
       min_iterations=min_iterations, **kwargs)
@@ -352,7 +372,10 @@ def gromov_wasserstein(
     tau_b: Optional[float] = 1.0,
     gw_unbalanced_correction: bool = True,
     **kwargs) -> GWOutput:
-  """Fits Gromov Wasserstein.
+  """Wrapper to solve a Gromov Wasserstein problem.
+
+  Wrapper that instantiates a quadratic problem (possibly with linear term
+  if the problem is fused) and calls a solver to output a solution.
 
   Args:
     geom_xx: a Geometry object for the first view.

--- a/ott/version.py
+++ b/ott/version.py
@@ -15,4 +15,4 @@
 
 """Current ott version."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -218,10 +218,18 @@ class GromovWassersteinTest(jax.test_util.JaxTestCase):
                                           a=a, b=b)
     solver = gromov_wasserstein.GromovWasserstein(rank=6)
     ot_gwlr = solver(prob)
+    solver = gromov_wasserstein.GromovWasserstein(rank=6, epsilon=1e-1)
+    ot_gwlreps = solver(prob)
     solver = gromov_wasserstein.GromovWasserstein(epsilon=5e-2)
     ot_gw = solver(prob)
 
+    # Test solutions look alike 
     self.assertGreater(0.1, jnp.linalg.norm(ot_gwlr.matrix - ot_gw.matrix))
+    self.assertGreater(0.1, jnp.linalg.norm(ot_gwlr.matrix - ot_gwlreps.matrix))
+    # Test at least some difference when adding bigger entropic regularization
+    self.assertGreater(
+      jnp.linalg.norm(ot_gwlr.matrix - ot_gwlreps.matrix), 1e-3)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Entropic regularisation was added to the LR-Sinkhorn solver in commit 

https://github.com/ott-jax/ott/commit/53a06973e417f579fc79795403f81ee829dbd575

The ability to choose that regularization strength is now propagated upstream in the GW-LR solver.