### PR TITLE
Batch `apply_lse_kernel` for `online=True`

### DIFF
--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -17,6 +17,8 @@
 """A geometry defined using 2 point clouds and a cost function between them."""
 from typing import Optional
 
+import math
+
 import jax
 import jax.numpy as jnp
 from ott.geometry import costs
@@ -70,8 +72,8 @@ class PointCloud(geometry.Geometry):
       # TODO(michalk8): check if > 0
       n, m = self.shape  # both can be zero
       self._bs = min(online, *(() + ((n,) if n else ()) + ((m,) if m else ())))
-      self._x_nsplit = jnp.ceil(n / self._bs).astype(int)
-      self._y_nsplit = jnp.ceil(m / self._bs).astype(int)
+      self._x_nsplit = int(math.ceil(n / self._bs))
+      self._y_nsplit = int(math.ceil(m / self._bs))
     else:
       self._bs = self._x_nsplit = self._y_nsplit = None
 

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -68,8 +68,10 @@ class PointCloud(geometry.Geometry):
     if online is not None:
       assert isinstance(online, int)
       self._bs = min(x.shape[0], y.shape[0], online)
+      self._x_nsplit = jnp.ceil(x.shape[0] / self._bs).astype(int)
+      self._y_nsplit = jnp.ceil(y.shape[0] / self._bs).astype(int)
     else:
-      self._bs = None
+      self._bs = self._x_nsplit = self._y_nsplit = None
 
     self._online = online
     self.power = power
@@ -161,10 +163,10 @@ class PointCloud(geometry.Geometry):
 
     if axis == 0:
       fun, size = body0, self.shape[1]
-      v, n = g, int(jnp.ceil(size / self._bs))
+      v, n = g, self._y_nsplit
     elif axis == 1:
       fun, size = body1, self.shape[0]
-      v, n = f, int(jnp.ceil(size / self._bs))
+      v, n = f, self._x_nsplit
     else:
       raise ValueError(axis)
 

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -71,7 +71,7 @@ class PointCloud(geometry.Geometry):
     if online is True:
       online = 1024
     if online:
-      assert online > 1, f"`online={online}` must be positive."
+      assert online > 0, f"`online={online}` must be positive."
       n, m = self.shape
       self._bs = min(online, online, *(() + ((n,) if n else ()) + ((m,) if m else ())))
       # use `floor` instead of `ceil` and handle the rest seperately

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -69,8 +69,7 @@ class PointCloud(geometry.Geometry):
 
     if online is not None and online:
       assert isinstance(online, int), type(online)
-      # TODO(michalk8): check if > 0
-      n, m = self.shape  # both can be zero
+      n, m = self.shape
       self._bs = min(online, *(() + ((n,) if n else ()) + ((m,) if m else ())))
       self._x_nsplit = int(math.ceil(n / self._bs))
       self._y_nsplit = int(math.ceil(m / self._bs))
@@ -112,8 +111,13 @@ class PointCloud(geometry.Geometry):
 
   @property
   def shape(self):
-    return (self.x.shape[0] if self.x is not None else 0,
-            self.y.shape[0] if self.y is not None else 0)
+    # in the process of flattening/unflattening in vmap, `__init__` can be called with dummy objects
+    # we optionally access `shape` in order to get the batch size
+    try:
+      return (self.x.shape[0] if self.x is not None else 0,
+              self.y.shape[0] if self.y is not None else 0)
+    except AttributeError:
+      return 0, 0
 
   @property
   def is_symmetric(self):

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -65,10 +65,11 @@ class PointCloud(geometry.Geometry):
     self.x = x
     self.y = self.x if y is None else y
 
-    if online is not None:
-      assert isinstance(online, int)
-      n, m = self.shape
-      self._bs = min(n, m, online)
+    if online is not None and online:
+      assert isinstance(online, int), type(online)
+      # TODO(michalk8): check if > 0
+      n, m = self.shape  # both can be zero
+      self._bs = min(online, *(() + ((n,) if n else ()) + ((m,) if m else ())))
       self._x_nsplit = jnp.ceil(n / self._bs).astype(int)
       self._y_nsplit = jnp.ceil(m / self._bs).astype(int)
     else:

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -28,14 +28,13 @@ from ott.geometry import ops
 @jax.tree_util.register_pytree_node_class
 class PointCloud(geometry.Geometry):
   """Defines geometry for 2 pointclouds (possibly 1 vs itself) using CostFn."""
-  BATCH_SIZE = 8192  # TODO(michalk8): could be passed as online: Optional[int] = None
 
   def __init__(self,
                x: jnp.ndarray,
                y: Optional[jnp.ndarray] = None,
                cost_fn: Optional[costs.CostFn] = None,
                power: float = 2.0,
-               online: bool = False,
+               online: Optional[int] = None,
                **kwargs):
     """Creates a geometry from two point clouds, using CostFn.
 
@@ -64,16 +63,16 @@ class PointCloud(geometry.Geometry):
     self._axis_norm = 0 if callable(self._cost_fn.norm) else None
 
     self.x = x
-    self._x_nsplits = jnp.ceil(x.shape[0] / self.BATCH_SIZE).astype(int)
-    if y is None:
-      self.y, self._y_nsplits = self.x, self._x_nsplits
+    self.y = self.x if y is None else y
+
+    if online is not None:
+      assert isinstance(online, int)
+      self._bs = min(x.shape[0], y.shape[0], online)
     else:
-      self.y = y
-      self._y_nsplits = jnp.ceil(y.shape[0] / self.BATCH_SIZE).astype(int)
+      self._bs = None
 
-    self.power = power
     self._online = online
-
+    self.power = power
     super().__init__(**kwargs)
 
   @property
@@ -121,7 +120,7 @@ class PointCloud(geometry.Geometry):
 
   @property
   def is_online(self) -> bool:
-    return self._online
+    return self._online is not None
 
   def apply_lse_kernel(self,
                        f: jnp.ndarray,
@@ -129,44 +128,51 @@ class PointCloud(geometry.Geometry):
                        eps: float,
                        vec: jnp.ndarray = None,
                        axis: int = 0) -> jnp.ndarray:
+    # TODO(michalk8): there's a bug somewhere
+    def body0(carry, i: int):
+      f, g, eps, vec = carry
+      y = jax.lax.dynamic_slice(self.y, (i, 0), (self._bs, self.y.shape[1]))
+      g_ = jax.lax.dynamic_slice(g, (i,), (self._bs,))
+      if self._axis_norm is None:
+        norm_y = self._norm_y
+      else:
+        norm_y = jax.lax.dynamic_slice(self._norm_y, (i,), (self._bs,))
+      h_res, h_sgn = app(self.x, y, self._norm_x, norm_y, f, g_, eps, vec, self._cost_fn, self.power)
+      return carry, (h_res, h_sgn)
+
+    def body1(carry, i: int):
+      f, g, eps, vec = carry
+      x = jax.lax.dynamic_slice(self.x, (i, 0), (self._bs, self.x.shape[1]))
+      f_ = jax.lax.dynamic_slice(f, (i,), (self._bs,))
+      if self._axis_norm is None:
+        norm_x = self._norm_x
+      else:
+        norm_x = jax.lax.dynamic_slice(self._norm_x, (i,), (self._bs,))
+      h_res, h_sgn = app(self.y, x, self._norm_y, norm_x, g, f_, eps, vec, self._cost_fn, self.power)
+      return carry, (h_res, h_sgn)
+
     if not self._online:
       return super().apply_lse_kernel(f, g, eps, vec, axis)
 
     app = jax.vmap(
         _apply_lse_kernel_xy,
-        in_axes=[
-            None, 0, None, self._axis_norm, None, 0, None, None, None, None
-        ])
+        in_axes=[None, 0, None, self._axis_norm, None, 0, None, None, None, None]
+    )
 
-    h_ress, h_sgns = [], []
     if axis == 0:
-      v = g
-      ys = jnp.array_split(self.y, self._y_nsplits)
-      norm_ys = [None] * self._y_nsplits if self._axis_norm is None else jnp.array_split(self._norm_y, self._y_nsplits)
-      gs = jnp.array_split(v, self._y_nsplits)
-      for y, norm_y, g_ in zip(ys, norm_ys, gs):
-        h_res, h_sgn = app(self.x, y, self._norm_x, self._norm_y if norm_y is None else norm_y,
-                           f, g_, eps, vec, self._cost_fn, self.power)
-        h_ress.append(h_res)
-        h_sgns.append(h_sgn)
+      fun, size = body0, self.shape[1]
+      v, n = g, int(jnp.ceil(size / self._bs))
     elif axis == 1:
-      v = f
-      xs = jnp.array_split(self.x, self._x_nsplits)
-      norm_xs = [None] * self._x_nsplits if self._axis_norm is None else jnp.array_split(self._norm_x, self._x_nsplits)
-      fs = jnp.array_split(v, self._x_nsplits)
-      for x, norm_x, f_ in zip(xs, norm_xs, fs):
-        h_res, h_sgn = app(self.y, x, self._norm_y, self._norm_x if norm_x is None else norm_x,
-                           g, f_, eps, vec, self._cost_fn, self.power)
-        h_ress.append(h_res)
-        h_sgns.append(h_sgn)
+      fun, size = body1, self.shape[0]
+      v, n = f, int(jnp.ceil(size / self._bs))
     else:
       raise ValueError(axis)
 
-    h_res = jnp.concatenate(h_ress)
-    h_sgn = jnp.concatenate(h_sgns)
-    h_res = eps * h_res - jnp.where(jnp.isfinite(v), v, 0)
+    _, (h_res, h_sign) = jax.lax.scan(fun, init=(f, g, eps, vec), xs=jnp.arange(n))
+    # truncate by `size` because of uneven batches + jax ignores out-of-bounds errors
+    h_res, h_sign = jnp.concatenate(h_res)[:size], jnp.concatenate(h_sign)[:size]
 
-    return h_res, h_sgn
+    return eps * h_res - jnp.where(jnp.isfinite(v), v, 0), h_sign
 
   def apply_kernel(self,
                    scaling: jnp.ndarray,

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -67,10 +67,11 @@ class PointCloud(geometry.Geometry):
     self.x = x
     self.y = self.x if y is None else y
 
+    # TODO(michalk8): retain bwd compat (online=True == guess)?
     if online is not None and online:
       assert isinstance(online, int), type(online)
       n, m = self.shape
-      self._bs = min(online, *(() + ((n,) if n else ()) + ((m,) if m else ())))
+      self._bs = min(online, online, *(() + ((n,) if n else ()) + ((m,) if m else ())))
       self._x_nsplit = int(math.ceil(n / self._bs))
       self._y_nsplit = int(math.ceil(m / self._bs))
     else:

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -67,9 +67,10 @@ class PointCloud(geometry.Geometry):
 
     if online is not None:
       assert isinstance(online, int)
-      self._bs = min(x.shape[0], y.shape[0], online)
-      self._x_nsplit = jnp.ceil(x.shape[0] / self._bs).astype(int)
-      self._y_nsplit = jnp.ceil(y.shape[0] / self._bs).astype(int)
+      n, m = self.shape
+      self._bs = min(n, m, online)
+      self._x_nsplit = jnp.ceil(n / self._bs).astype(int)
+      self._y_nsplit = jnp.ceil(m / self._bs).astype(int)
     else:
       self._bs = self._x_nsplit = self._y_nsplit = None
 

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -130,26 +130,25 @@ class PointCloud(geometry.Geometry):
                        eps: float,
                        vec: jnp.ndarray = None,
                        axis: int = 0) -> jnp.ndarray:
-    # TODO(michalk8): there's a bug somewhere
     def body0(carry, i: int):
       f, g, eps, vec = carry
-      y = jax.lax.dynamic_slice(self.y, (i, 0), (self._bs, self.y.shape[1]))
-      g_ = jax.lax.dynamic_slice(g, (i,), (self._bs,))
+      y = jax.lax.dynamic_slice(self.y, (i * self._bs, 0), (self._bs, self.y.shape[1]))
+      g_ = jax.lax.dynamic_slice(g, (i * self._bs,), (self._bs,))
       if self._axis_norm is None:
         norm_y = self._norm_y
       else:
-        norm_y = jax.lax.dynamic_slice(self._norm_y, (i,), (self._bs,))
+        norm_y = jax.lax.dynamic_slice(self._norm_y, (i * self._bs,), (self._bs,))
       h_res, h_sgn = app(self.x, y, self._norm_x, norm_y, f, g_, eps, vec, self._cost_fn, self.power)
       return carry, (h_res, h_sgn)
 
     def body1(carry, i: int):
       f, g, eps, vec = carry
-      x = jax.lax.dynamic_slice(self.x, (i, 0), (self._bs, self.x.shape[1]))
-      f_ = jax.lax.dynamic_slice(f, (i,), (self._bs,))
+      x = jax.lax.dynamic_slice(self.x, (i * self._bs, 0), (self._bs, self.x.shape[1]))
+      f_ = jax.lax.dynamic_slice(f, (i * self._bs,), (self._bs,))
       if self._axis_norm is None:
         norm_x = self._norm_x
       else:
-        norm_x = jax.lax.dynamic_slice(self._norm_x, (i,), (self._bs,))
+        norm_x = jax.lax.dynamic_slice(self._norm_x, (i * self._bs,), (self._bs,))
       h_res, h_sgn = app(self.y, x, self._norm_y, norm_x, g, f_, eps, vec, self._cost_fn, self.power)
       return carry, (h_res, h_sgn)
 

--- a/tests/core/sinkhorn_online_large_test.py
+++ b/tests/core/sinkhorn_online_large_test.py
@@ -15,12 +15,15 @@
 
 # Lint as: python3
 """Tests Online option for PointCloud geometry."""
+from functools import partial
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 import jax.numpy as jnp
 import jax.test_util
+import numpy as np
 from ott.core import sinkhorn
+from ott.core.sinkhorn import SinkhornOutput
 from ott.geometry import pointcloud
 
 
@@ -57,6 +60,74 @@ class SinkhornOnlineTest(jax.test_util.JaxTestCase):
         lse_mode=lse_mode,
         implicit_differentiation=True).errors
     err = errors[errors > -1][-1]
+    self.assertGreater(threshold, err)
+
+  @parameterized.parameters([1], [13], [402], [4000])
+  def test_online_matches_offline_size(self, online: int):
+    threshold, rtol, atol = 1e-1, 1e-6, 1e-6
+    geom_offline = pointcloud.PointCloud(self.x, self.y, epsilon=1, online=False)
+    geom_online = pointcloud.PointCloud(self.x, self.y, epsilon=1, online=online)
+
+    sol_online = sinkhorn.sinkhorn(
+      geom_online,
+      a=self.a,
+      b=self.b,
+      threshold=threshold,
+      lse_mode=True,
+      implicit_differentiation=True
+    )
+    errors_online = sol_online.errors
+    err_online = errors_online[errors_online > -1][-1]
+
+    sol_offline = sinkhorn.sinkhorn(
+      geom_offline,
+      a=self.a,
+      b=self.b,
+      threshold=threshold,
+      lse_mode=True,
+      implicit_differentiation=True
+    )
+
+    self.assertGreater(threshold, err_online)
+    np.testing.assert_allclose(sol_online.matrix, sol_offline.matrix, rtol=rtol, atol=atol)
+    np.testing.assert_allclose(sol_online.a, sol_offline.a, rtol=rtol, atol=atol)
+    np.testing.assert_allclose(sol_online.b, sol_offline.b, rtol=rtol, atol=atol)
+
+  def test_online_sinkhorn_jit(self):
+    threshold = 1e-1
+    geom = pointcloud.PointCloud(self.x, self.y, epsilon=1, online=512)
+    errors = sinkhorn.sinkhorn(
+      geom,
+      a=self.a,
+      b=self.b,
+      threshold=threshold,
+      jit=True,
+      lse_mode=True,
+      implicit_differentiation=True
+    ).errors
+    err = errors[errors > -1][-1]
+
+    self.assertGreater(threshold, err)
+
+  def test_online_external_jit(self):
+    @partial(jax.jit, static_argnums=1)
+    def callback(epsilon: float, online: int) -> SinkhornOutput:
+      geom = pointcloud.PointCloud(self.x, self.y, epsilon=epsilon, online=online)
+      return sinkhorn.sinkhorn(
+        geom,
+        a=self.a,
+        b=self.b,
+        threshold=threshold,
+        jit=True,
+        lse_mode=True,
+        implicit_differentiation=True
+      )
+
+    threshold = 1e-1
+    sol = callback(epsilon=1, online=42)
+    errors = sol.errors
+    err = errors[errors > -1][-1]
+
     self.assertGreater(threshold, err)
 
 


### PR DESCRIPTION
As discussed in #20 , this PR fixes ``online`` by batching ``apply_lse_kernel`` and running the fully-vectorized computation on a batch of shape `n * batch_size` or `m * batch_size` (depends of the axis) instead of `n * m`. Minor inefficiency comes from that this approach computed the kernel application for extra `{n,m} % batch_size` points, given that result of each iteration of `jax.lax.scan` must have the same shape.

@LaetitiaPapaxanthos there are 2 points I am unsure how you want to handle:
- [x] ~~shall the backward compatibility be retained and allow `backward=True`? In that case, we'd need to use some default value, that can either be fixed or depend on the number of points (from our benchmarks, value of `1024` seems to work well)~~ **UPDATE**: `online=True` is the same as `online=1024`
- [x] ~~currently, the batch size is the same when using `axis=0` or `axis=1`, but this could be done in axis-specific manner~~ **UPDATE**: kept the same batch size for both axes

TODOs:
- [x] add new tests (and depending on the 1st point above, might need to adjust old tests where `online=True`)
- [x] update docs

closes #20