### PR TITLE
not converged logic

### DIFF
--- a/ott/core/sinkhorn.py
+++ b/ott/core/sinkhorn.py
@@ -464,7 +464,7 @@ class Sinkhorn:
     err = state.errors[iteration // self.inner_iterations - 1, 0]
     return jnp.logical_or(
         iteration == 0,
-        jnp.logical_and(jnp.isfinite(err), err > self.threshold))
+        jnp.logical_or(jnp.logical_not(jnp.isfinite(err)), err > self.threshold))
 
   @property
   def outer_iterations(self):

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -281,8 +281,8 @@ class LRSinkhorn(sinkhorn.Sinkhorn):
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,
-        jnp.logical_and(
-            jnp.isfinite(costs[i - 1]),
+        jnp.logical_or(
+            jnp.logical_not(jnp.isfinite(costs[i - 1])),
             jnp.logical_not(jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))))
 
   def lr_costs(self, ot_prob, state, iteration):

--- a/ott/core/was_solver.py
+++ b/ott/core/was_solver.py
@@ -95,6 +95,6 @@ class WassersteinSolver:
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,
-        jnp.logical_and(
-            jnp.isfinite(costs[i - 1]),
+        jnp.logical_or(
+            jnp.logical_not(jnp.isfinite(costs[i - 1])),
             jnp.logical_not(jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))))


### PR DESCRIPTION
Hi,
we noticed that the current logic of the `not_converged()` (in `was_solver.py`, `sinkhorn.py` and `sinkhorn_lr.py`) required `jnp.isfinite(err)` as a measure for `non-convergence` and since this is the function that is eventually used by `GW` we always got a conveged flag. 
Specifically the logic is currently in the form:
`(iteration cond) or (jnp.isfinite(err) and (threshold_cond))`
well as the question is `not_converged()` we want:
`(iteration cond) or (jnp.logical_not(jnp.isfinite(err)) or (threshold_cond)`.
This explains the errors we encountered with `nan`s in result and `converged=True`.
We hope this makes sense :) 