### PR TITLE
minor bug fix: jit bug from none relative epsilon in control flow

### DIFF
--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -96,8 +96,8 @@ class Geometry:
 
     rel = self._relative_epsilon
     trigger = ((self._scale_epsilon is None) and
-               (rel or rel is None) and
-               (self._epsilon_init is None or rel))
+               (rel is None) and
+               (self._epsilon_init is None))
     if (self._scale_epsilon is None) and (trigger is not None):  # for dry run
       return jnp.where(
           trigger, jax.lax.stop_gradient(self.mean_cost_matrix), 1.0)


### PR DESCRIPTION
Bug in logic for scale_epsilon property in Geometry class, not compatible with jit. 

Self contained example below, simplified from notebook from ott docs on word embeddings (https://ott-jax.readthedocs.io/en/latest/notebooks/One_Sinkhorn.html)

`

        import jax
        import jax.numpy as jnp
        import numpy as np
        import os, sys
        from ott.geometry import geometry
        from ott.geometry import pointcloud
        from ott.tools.sinkhorn_divergence import sinkhorn_divergence
        from functools import partial

        n, m, p, b = 5, 5, 10, 7
        keys = jax.random.split(self.rng, 5)
        x = jax.random.normal(keys[0], (n, p))
        y = jax.random.normal(keys[1], (m, p)) + 1

        geom = pointcloud.PointCloud(x, y, power=2)

        @partial(jax.vmap, in_axes=[0, None, None, None])
        @partial(jax.vmap, in_axes=[None, 0, None, None])
        def sink_div(hist_1, hist_2, cost, epsilon):
            return sinkhorn_divergence(
                geometry.Geometry, cost, cost, cost, a=hist_1, b=hist_2, epsilon=epsilon
            ).divergence

        HIST_1 = jax.random.normal(keys[3], (b, n)) ** 2
        HIST_1 = HIST_1 / jnp.sum(HIST_1, axis=(1,), keepdims=True)

        HIST_2 = jax.random.normal(keys[4], (b, m)) ** 2
        HIST_2 = HIST_2 / jnp.sum(HIST_2, axis=(1,), keepdims=True)

        try:
            sink_div(HIST_1, HIST_2, geom.cost_matrix, 0.01).shape
            print("without jit works")
        except:
            print("without jit doesnt work")

        try:
            jax.jit(sink_div)(HIST_1, HIST_2, geom.cost_matrix, 0.01).shape
            print("with jit works")
        except:
            print("with jit doesnt work")

`