### PR TITLE
Fix jit issue with relative epsilon and copying epsilons

### DIFF
--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -96,9 +96,8 @@ class Geometry:
 
     rel = self._relative_epsilon
     trigger = ((self._scale_epsilon is None) and
-               (rel is None) and
-               (self._epsilon_init is None or rel))
-
+               ((rel is None and self._epsilon_init is None) or rel))
+               
     if (self._scale_epsilon is None) and (trigger is not None):  # for dry run
       return jnp.where(
           trigger, jax.lax.stop_gradient(self.mean_cost_matrix), 1.0)

--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -96,8 +96,9 @@ class Geometry:
 
     rel = self._relative_epsilon
     trigger = ((self._scale_epsilon is None) and
-               (rel or rel is None) and
+               (rel is None) and
                (self._epsilon_init is None or rel))
+
     if (self._scale_epsilon is None) and (trigger is not None):  # for dry run
       return jnp.where(
           trigger, jax.lax.stop_gradient(self.mean_cost_matrix), 1.0)
@@ -191,6 +192,7 @@ class Geometry:
     self._epsilon_init = scheduler._target_init
     self._relative_epsilon = False
     self._scale_epsilon = other.scale_epsilon
+    return self
 
   # The functions below are at the core of Sinkhorn iterations, they
   # are implemented here in their default form, either in lse (using directly

--- a/ott/tools/sinkhorn_divergence.py
+++ b/ott/tools/sinkhorn_divergence.py
@@ -70,8 +70,8 @@ def sinkhorn_divergence(
 
   geometries = (geometries + (None,) * max(0, 3 - len(geometries)))[:3]
   if share_epsilon:
-    for geom in filter(None, geometries[1:(2 if static_b else 3)]):
-      geom.copy_epsilon(geometries[0])
+    geometries = (geometries[0],) + tuple(geom.copy_epsilon(geometries[0]) for geom in filter(None, geometries[1:(2 if static_b else 3)]))
+      
 
   a = jnp.ones((num_a,)) / num_a if a is None else a
   b = jnp.ones((num_b,)) / num_b if b is None else b

--- a/ott/tools/sinkhorn_divergence.py
+++ b/ott/tools/sinkhorn_divergence.py
@@ -70,8 +70,10 @@ def sinkhorn_divergence(
 
   geometries = (geometries + (None,) * max(0, 3 - len(geometries)))[:3]
   if share_epsilon:
-    geometries = (geometries[0],) + tuple(geom.copy_epsilon(geometries[0]) for geom in filter(None, geometries[1:(2 if static_b else 3)]))
-      
+    geometries = (geometries[0],) + tuple(
+            geom.copy_epsilon(geometries[0])
+            for geom in filter(None, geometries[1 : (2 if static_b else 3)])
+        )
 
   a = jnp.ones((num_a,)) / num_a if a is None else a
   b = jnp.ones((num_b,)) / num_b if b is None else b


### PR DESCRIPTION
Rearranged logic and changed `copy_epsilon` to not change-in-place.

https://colab.research.google.com/drive/1MYf0_rtuA8-mKuP1ZffrkWvIFJDBpUvh?usp=sharing


Clone updated repo
`!git clone https://github.com/JTT94/ott.git
`

Run test case with new code

`

    import os, sys
    
    sys.path.append('./ott') 
    
    import jax
    import jax.numpy as jnp
    import numpy as np
    import os, sys
    from ott.geometry import geometry
    from ott.geometry import pointcloud
    from ott.tools.sinkhorn_divergence import sinkhorn_divergence
    from functools import partial
    
    n, m, p, b = 5, 5, 10, 7
    rng = jax.random.PRNGKey(0)
    keys = jax.random.split(rng, 5)
    x = jax.random.normal(keys[0], (n, p))
    y = jax.random.normal(keys[1], (m, p)) + 1
    
    geom = pointcloud.PointCloud(x, y, power=2)
    
    @partial(jax.vmap, in_axes=[0, None, None, None])
    @partial(jax.vmap, in_axes=[None, 0, None, None])
    def sink_div(hist_1, hist_2, cost, epsilon):
        return sinkhorn_divergence(
            geometry.Geometry, cost, cost, cost, a=hist_1, b=hist_2, epsilon=epsilon
        ).divergence
    
    HIST_1 = jax.random.normal(keys[3], (b, n)) ** 2
    HIST_1 = HIST_1 / jnp.sum(HIST_1, axis=(1,), keepdims=True)
    
    HIST_2 = jax.random.normal(keys[4], (b, m)) ** 2
    HIST_2 = HIST_2 / jnp.sum(HIST_2, axis=(1,), keepdims=True)
    
    
    jax.jit(sink_div)(HIST_1, HIST_2, geom.cost_matrix, 0.01)

`