### PR TITLE
Bug/scale cost

### DIFF
--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -36,7 +36,7 @@ class PointCloud(geometry.Geometry):
                y: Optional[jnp.ndarray] = None,
                cost_fn: Optional[costs.CostFn] = None,
                power: float = 2.0,
-               online: Optional[Union[bool, int]] = None,
+               online: Union[bool, int] = False,
                scale_cost: Optional[Union[float, str]] = None,
                **kwargs):
     """Creates a geometry from two point clouds, using CostFn.
@@ -139,7 +139,7 @@ class PointCloud(geometry.Geometry):
 
   @property
   def is_online(self) -> bool:
-    return self._online is not None
+    return self._online > 0
 
   @property
   def scale_cost(self):

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -139,7 +139,7 @@ class PointCloud(geometry.Geometry):
 
   @property
   def is_online(self) -> bool:
-    return self._online > 0
+    return self._online is not None and self._online # for backward compatibility
 
   @property
   def scale_cost(self):

--- a/tests/geometry/scaling_cost_test.py
+++ b/tests/geometry/scaling_cost_test.py
@@ -109,7 +109,7 @@ class ScaleCostTest(parameterized.TestCase):
     geom0 = pointcloud.PointCloud(
         self.x, self.y, epsilon=self.eps, scale_cost=scale, online=4)
     geom1 = pointcloud.PointCloud(
-        self.x, self.y, epsilon=self.eps, scale_cost=scale, online=None)
+        self.x, self.y, epsilon=self.eps, scale_cost=scale, online=False)
     geom2 = pointcloud.PointCloud(
         self.x, self.y, epsilon=self.eps, scale_cost=scale, online=True)
     np.testing.assert_allclose(geom0.scale_cost, geom1.scale_cost, rtol=1e-4)


### PR DESCRIPTION
Fixes #53 
- adapted the ```is_online``` logic
- made ```online: Union[bool, int] = False```
- fixed corresponding test ```test_online_matches_notonline_pointcloud``` 
