### PR TITLE
ensure 3 geom objects returned when copying epsilons

### DIFF
--- a/ott/tools/sinkhorn_divergence.py
+++ b/ott/tools/sinkhorn_divergence.py
@@ -71,8 +71,8 @@ def sinkhorn_divergence(
   geometries = (geometries + (None,) * max(0, 3 - len(geometries)))[:3]
   if share_epsilon:
     geometries = (geometries[0],) + tuple(
-            geom.copy_epsilon(geometries[0])
-            for geom in filter(None, geometries[1 : (2 if static_b else 3)])
+            geom.copy_epsilon(geometries[0]) if geom is not None else None
+            for geom in geometries[1 : (2 if static_b else 3)]
         )
 
   a = jnp.ones((num_a,)) / num_a if a is None else a


### PR DESCRIPTION
All tests but one passed. 

The failed test does not appear significant error, 10^-7, maybe adjust test to have a tolerance.

===============
FAIL: test_euclidean_point_cloud2 (use_lrcgeom=False, init_type='rank_2') (__main__.SinkhornLRTest)
SinkhornLRTest.test_euclidean_point_cloud2 (use_lrcgeom=False, init_type='rank_2')
test_euclidean_point_cloud(use_lrcgeom=False, init_type='rank_2')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jamesthornton/miniconda3/envs/diffusions/lib/python3.8/site-packages/absl/testing/parameterized.py", line 314, in bound_param_test
    return test_method(self, **testcase_params)
  File "./tests/core/sinkhorn_lr_test.py", line 87, in test_euclidean_point_cloud
    self.assertGreater(cost_1, cost_2)
AssertionError: DeviceArray(0.66044074, dtype=float32) not greater than DeviceArray(0.6604408, dtype=float32)

----------------------------------------------------------------------
