### PR TITLE
General cost fn

### DIFF
--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -322,7 +322,7 @@ class PointCloud(geometry.Geometry):
       A jnp.ndarray, [num_b, batch] if axis=0 or [num_a, batch] if axis=1
     """
     if fn is None:
-      return self.vec_apply_cost(arr, axis, fn=fn)
+      return self._apply_cost(arr, axis, fn=fn)
     # Switch to efficient computation for the squared euclidean case.
     return jnp.where(jnp.logical_and(self.is_squared_euclidean,
                                      geometry.is_affine(fn)),

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -96,14 +96,14 @@ class PointCloud(geometry.Geometry):
     if self._axis_norm == 0:
       return self._cost_fn.norm(self.x)
     elif self._axis_norm is None:
-      return 0
+      return jnp.zeros(self.x.shape[0])
 
   @property
   def _norm_y(self):
     if self._axis_norm == 0:
       return self._cost_fn.norm(self.y)
     elif self._axis_norm is None:
-      return 0
+      return jnp.zeros(self.y.shape[0])
 
   @property
   def cost_matrix(self):

--- a/tests/geometry/geometry_pointcloud_generalcost_test.py
+++ b/tests/geometry/geometry_pointcloud_generalcost_test.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Copyright 2022 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Tests for apply_cost and apply_kernel."""
+
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+import numpy as np
+from ott.geometry import geometry
+from ott.geometry import pointcloud
+from ott.geometry.costs import Cosine
+
+class ApplyTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.rng = jax.random.PRNGKey(0)
+
+  def test_general_cost_fn(self):
+    """Test non-vec cost apply to vec."""
+    n, m, p, b = 5, 8, 10, 7
+    keys = jax.random.split(self.rng, 5)
+    x = jax.random.normal(keys[0], (n, p))
+    y = jax.random.normal(keys[1], (m, p)) + 1
+    vec0 = jax.random.normal(keys[2], (n, b))
+    vec1 = jax.random.normal(keys[3], (m, b))
+
+    geom = pointcloud.PointCloud(x, y, cost_fn=Cosine(), online=False)
+    cost = geom.cost_matrix
+    prod0 = geom.apply_cost(vec0, axis=0)
+    prod1 = geom.apply_cost(vec1, axis=1)
+    
+    geom = geometry.Geometry(cost)
+    prod0_geom = geom.apply_cost(vec0, axis=0)
+    prod1_geom = geom.apply_cost(vec1, axis=1)
+
+    np.testing.assert_allclose(prod0_geom, prod0, rtol=1e-03, atol=1e-02)
+    np.testing.assert_allclose(prod1_geom, prod1, rtol=1e-03, atol=1e-02)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
- Change _norm_x (resp y) to default to jnp.zeros(x.shape[0]) (resp y) to avoid shape issues
- Change apply_cost to run _apply_cost when pre function is None, currently defaults to vec_apply_cost which would not compute correct cross terms
- Added test for apply_cost when init cost matrix with function in pointcloud geom vs cost_matrix in base geom

Not ran all tests locally, let GitHub actions run tests