### PR TITLE
Set converged logic

### DIFF
--- a/ott/core/continuous_barycenter.py
+++ b/ott/core/continuous_barycenter.py
@@ -153,9 +153,7 @@ class WassersteinBarycenter(was_solver.WassersteinSolver):
       rng: int = 0
       ) -> BarycenterState:    
     bar_fn = jax.jit(iterations, static_argnums=1) if self.jit else iterations
-    out = bar_fn(self, bar_size, bar_prob, x_init, rng) 
-    iteration = jnp.sum(out.costs != 0)
-    convergence = jnp.logical_not(self.not_converged(out, iteration))
+    out = bar_fn(self, bar_size, bar_prob, x_init, rng)
     return out
 
   def init_state(self, bar_prob, bar_size, x_init, rng
@@ -193,7 +191,7 @@ def iterations(solver: WassersteinBarycenter,
   """A jittable Wasserstein barycenter outer loop."""  
   def cond_fn(iteration, constants, state):
     solver, _ = constants
-    return solver.not_converged(state, iteration)
+    return solver._continue(state, iteration)
 
   def body_fn(iteration, constants, state, compute_error):
     del compute_error  # Always assumed True

--- a/ott/core/continuous_barycenter.py
+++ b/ott/core/continuous_barycenter.py
@@ -191,7 +191,7 @@ def iterations(solver: WassersteinBarycenter,
   """A jittable Wasserstein barycenter outer loop."""  
   def cond_fn(iteration, constants, state):
     solver, _ = constants
-    return solver._continue(state, iteration)
+    return solver.not_converged(state, iteration)
 
   def body_fn(iteration, constants, state, compute_error):
     del compute_error  # Always assumed True

--- a/ott/core/continuous_barycenter.py
+++ b/ott/core/continuous_barycenter.py
@@ -24,10 +24,6 @@ from ott.core import fixed_point_loop
 from ott.core import problems
 from ott.core import bar_problems
 from ott.core import was_solver
-from ott.geometry import epsilon_scheduler
-from ott.geometry import geometry
-from ott.geometry import costs
-from ott.geometry import low_rank
 from ott.geometry import pointcloud
 
 
@@ -191,7 +187,7 @@ def iterations(solver: WassersteinBarycenter,
   """A jittable Wasserstein barycenter outer loop."""  
   def cond_fn(iteration, constants, state):
     solver, _ = constants
-    return solver.not_converged(state, iteration)
+    return solver._continue(state, iteration)
 
   def body_fn(iteration, constants, state, compute_error):
     del compute_error  # Always assumed True

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -210,7 +210,7 @@ def iterations(solver: GromovWasserstein,
 
   def cond_fn(iteration, constants, state):
     solver = constants
-    return solver.not_converged(state, iteration)
+    return solver._continue(state, iteration)
 
   def body_fn(iteration, constants, state, compute_error):
     del compute_error  # Always assumed True for outer loop of GW.

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -163,7 +163,8 @@ class GromovWasserstein(WassersteinSolver):
     linear_state = out.linear_state.set_cost(linearization, True, True)
     iteration = jnp.sum(out.costs != -1)
     # note(zoe.piran): slicing `linear_convergence[:iteration]` can be removed as `-1` also evaluates to true.
-    convergence = jnp.all(out.linear_convergence[:iteration])
+    convergence = jnp.logical_and(iteration < self.max_iterations,
+                                  jnp.all(out.linear_convergence[:iteration]))
     return out.set(linear_state=linear_state,
                    convergence=convergence)
 

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -162,8 +162,8 @@ class GromovWasserstein(was_solver.WassersteinSolver):
           self.epsilon,
           jax.lax.stop_gradient(out.old_transport_mass))
     linear_state = out.linear_state.set_cost(linearization, True, True)
-    iteration = jnp.sum(out.costs != 0)
-    convergence = jnp.logical_not(self.not_converged(out, iteration))
+    iteration = jnp.sum(out.costs != -1)
+    convergence = self.converged(out, iteration)
     return out.set(linear_state=linear_state,
                    convergence=convergence)
 

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -26,7 +26,7 @@ from ott.core import quad_problems
 from ott.core import sinkhorn
 from ott.core import sinkhorn_lr
 
-from ott.core.was_solver import WassersteinSolver
+from ott.core import was_solver
 from ott.geometry import epsilon_scheduler
 from ott.geometry import geometry
 from ott.geometry import low_rank
@@ -120,7 +120,7 @@ class GWState(NamedTuple):
 
 
 @jax.tree_util.register_pytree_node_class
-class GromovWasserstein(WassersteinSolver):
+class GromovWasserstein(was_solver.WassersteinSolver):
   """A Gromov Wasserstein solver, built on generic template."""
 
   def __call__(self, prob: quad_problems.QuadraticProblem) -> GWOutput:

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -162,9 +162,8 @@ class GromovWasserstein(WassersteinSolver):
           jax.lax.stop_gradient(out.old_transport_mass))
     linear_state = out.linear_state.set_cost(linearization, True, True)
     iteration = jnp.sum(out.costs != -1)
-    # note(zoe.piran): slicing `linear_convergence[:iteration]` can be removed as `-1` also evaluates to true.
     convergence = jnp.logical_and(iteration < self.max_iterations,
-                                  jnp.all(out.linear_convergence[:iteration]))
+                                  jnp.all(out.linear_convergence))
     return out.set(linear_state=linear_state,
                    convergence=convergence)
 
@@ -211,7 +210,7 @@ def iterations(solver: GromovWasserstein,
 
   def cond_fn(iteration, constants, state):
     solver = constants
-    return solver._continue(state, iteration)
+    return solver.not_converged(state, iteration)
 
   def body_fn(iteration, constants, state, compute_error):
     del compute_error  # Always assumed True for outer loop of GW.

--- a/ott/core/sinkhorn.py
+++ b/ott/core/sinkhorn.py
@@ -461,10 +461,11 @@ class Sinkhorn:
     return state.set(errors=errors)
 
   def not_converged(self, state, iteration):
+    """ logic: break loop if costs converged or are infinite"""
     err = state.errors[iteration // self.inner_iterations - 1, 0]
     return jnp.logical_or(
         iteration == 0,
-        jnp.logical_or(jnp.logical_not(jnp.isfinite(err)), err > self.threshold))
+        jnp.logical_and(jnp.isfinite(err), err > self.threshold))
 
   @property
   def outer_iterations(self):

--- a/ott/core/sinkhorn.py
+++ b/ott/core/sinkhorn.py
@@ -460,7 +460,7 @@ class Sinkhorn:
         state.errors.at[iteration // self.inner_iterations, :].set(err))
     return state.set(errors=errors)
 
-  def not_converged(self, state, iteration):
+  def _continue(self, state, iteration):
     """ logic: break loop if costs converged or are infinite"""
     err = state.errors[iteration // self.inner_iterations - 1, 0]
     return jnp.logical_or(
@@ -531,7 +531,7 @@ def iterations(ot_prob, solver, init):
 
   def cond_fn(iteration, const, state):
     _, solver = const
-    return solver.not_converged(state, iteration)
+    return solver._continue(state, iteration)
 
   def body_fn(iteration, const, state, compute_error):
     ot_prob, solver = const

--- a/ott/core/sinkhorn.py
+++ b/ott/core/sinkhorn.py
@@ -460,8 +460,8 @@ class Sinkhorn:
         state.errors.at[iteration // self.inner_iterations, :].set(err))
     return state.set(errors=errors)
 
-  def _continue(self, state, iteration):
-    """ logic: break loop if costs converged or are infinite"""
+  def not_converged(self, state, iteration):
+    """ continue while not_converged (where infinity implies `convergence` here)"""
     err = state.errors[iteration // self.inner_iterations - 1, 0]
     return jnp.logical_or(
         iteration == 0,
@@ -531,7 +531,7 @@ def iterations(ot_prob, solver, init):
 
   def cond_fn(iteration, const, state):
     _, solver = const
-    return solver._continue(state, iteration)
+    return solver.not_converged(state, iteration)
 
   def body_fn(iteration, const, state, compute_error):
     ot_prob, solver = const

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -279,8 +279,8 @@ class LRSinkhorn(sinkhorn.Sinkhorn):
   def norm_error(self):
     return (self._norm_error,)
 
-  def _continue(self, state, iteration):
-    """ logic: break loop if costs converged or are infinite"""
+  def not_converged(self, state, iteration):
+    """ continue while not_converged (where infinity implies `convergence` here)"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -280,11 +280,12 @@ class LRSinkhorn(sinkhorn.Sinkhorn):
     return (self._norm_error,)
 
   def not_converged(self, state, iteration):
+    """ logic: break loop if costs converged or are infinite"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,
-        jnp.logical_or(
-            jnp.logical_not(jnp.isfinite(costs[i - 1])),
+        jnp.logical_and(
+            jnp.isfinite(costs[i - 1]),
             jnp.logical_not(jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))))
 
   def lr_costs(self, ot_prob, state, iteration):

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -279,7 +279,7 @@ class LRSinkhorn(sinkhorn.Sinkhorn):
   def norm_error(self):
     return (self._norm_error,)
 
-  def not_converged(self, state, iteration):
+  def _continue(self, state, iteration):
     """ logic: break loop if costs converged or are infinite"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(

--- a/ott/core/was_solver.py
+++ b/ott/core/was_solver.py
@@ -92,9 +92,16 @@ class WassersteinSolver:
         **aux_data)
 
   def not_converged(self, state, iteration):
+    """ logic: break loop if costs converged or are infinite"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,
-        jnp.logical_or(
-            jnp.logical_not(jnp.isfinite(costs[i - 1])),
+        jnp.logical_and(
+            jnp.isfinite(costs[i - 1]),
             jnp.logical_not(jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))))
+
+  def converged(self, state, iteration):
+    costs, i, tol = state.costs, iteration, self.threshold
+    if jnp.logical_not(jnp.isfinite(costs[i - 1])):
+        return False
+    return jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol)

--- a/ott/core/was_solver.py
+++ b/ott/core/was_solver.py
@@ -91,11 +91,22 @@ class WassersteinSolver:
         threshold=children[3],
         **aux_data)
 
-  def not_converged(self, state, iteration):
+  def _converged(self, state, iteration):
+    costs, i, tol = state.costs, iteration, self.threshold
+    return jnp.logical_and(
+        i >= 2,
+        jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))
+
+  def _diverged(self, state, iteration):
     """ continue while not_converged (where infinity implies `convergence` here)"""
+    costs, i, tol = state.costs, iteration, self.threshold
+    return jnp.logical_not(jnp.isfinite(costs[i - 1]))
+
+  def _continue(self, state, iteration):
+    """ continue while not(converged) and not(diverged)"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,
         jnp.logical_and(
-            jnp.isfinite(costs[i - 1]),
-            jnp.logical_not(jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))))
+            jnp.logical_not(self._diverged(state, iteration)),
+            jnp.logical_not(self._converged(state, iteration))))

--- a/ott/core/was_solver.py
+++ b/ott/core/was_solver.py
@@ -91,8 +91,8 @@ class WassersteinSolver:
         threshold=children[3],
         **aux_data)
 
-  def _continue(self, state, iteration):
-    """ logic: break loop if costs converged or are infinite"""
+  def not_converged(self, state, iteration):
+    """ continue while not_converged (where infinity implies `convergence` here)"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
         i <= 2,

--- a/ott/core/was_solver.py
+++ b/ott/core/was_solver.py
@@ -91,7 +91,7 @@ class WassersteinSolver:
         threshold=children[3],
         **aux_data)
 
-  def not_converged(self, state, iteration):
+  def _continue(self, state, iteration):
     """ logic: break loop if costs converged or are infinite"""
     costs, i, tol = state.costs, iteration, self.threshold
     return jnp.logical_or(
@@ -99,9 +99,3 @@ class WassersteinSolver:
         jnp.logical_and(
             jnp.isfinite(costs[i - 1]),
             jnp.logical_not(jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))))
-
-  def converged(self, state, iteration):
-    costs, i, tol = state.costs, iteration, self.threshold
-    return jnp.logical_and(
-            jnp.isfinite(costs[i - 1]),
-            jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))

--- a/ott/core/was_solver.py
+++ b/ott/core/was_solver.py
@@ -102,6 +102,6 @@ class WassersteinSolver:
 
   def converged(self, state, iteration):
     costs, i, tol = state.costs, iteration, self.threshold
-    if jnp.logical_not(jnp.isfinite(costs[i - 1])):
-        return False
-    return jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol)
+    return jnp.logical_and(
+            jnp.isfinite(costs[i - 1]),
+            jnp.isclose(costs[i - 2], costs[i - 1], rtol=tol))


### PR DESCRIPTION
**a suggestion for the `converged` <-> `not_converged` logic.**

_Briefly_:
[1] change the naming `not_converged` -> `_continue` making the functionality clearer to the user.
[2] removal of `converged()` from `GW` (`was_solver`) and defining `convergence` based on `linear_convergence`. Here we demand that all iterations converged (we are debating whether this is necessary or using the last iteration suffices) and that `iterations < max_iterations`. 

! the next step is to decide whether we prompt a warning in the case of non-convergence and state the reason (`non-finite` or `max_iterations`)