### PR TITLE
Fix `LRSinkhornOutput.apply` with batches

### DIFF
--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -141,8 +141,8 @@ class LRSinkhornOutput(NamedTuple):
   def apply(self, inputs: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
     """Applies the transport to a ndarray; axis=1 for its transpose."""
     q, r = (self.q, self.r) if axis == 1 else (self.r, self.q)
-    inputs = inputs.reshape(r.shape[0], -1)
-    return jnp.dot(q, jnp.dot(r.T, inputs) / self.g.reshape(-1, 1)).squeeze()
+    inputs = inputs.reshape(-1, r.shape[0])  # (batch, ...)
+    return jnp.dot(q, jnp.dot(r.T, inputs.T) / self.g.reshape(-1, 1)).T.squeeze()
 
   def marginal(self, axis: int) -> jnp.ndarray:
     length = self.q.shape[0] if axis == 0 else self.r.shape[0]

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -142,7 +142,7 @@ class LRSinkhornOutput(NamedTuple):
     """Applies the transport to a ndarray; axis=1 for its transpose."""
     q, r = (self.q, self.r) if axis == 1 else (self.r, self.q)
     inputs = inputs.reshape(-1, r.shape[0])  # (batch, ...)
-    return jnp.dot(q, jnp.dot(r.T, inputs.T) / self.g.reshape(-1, 1)).T.squeeze()
+    return jnp.dot(q, jnp.dot(inputs, r).T / self.g.reshape(-1, 1)).T.squeeze()
 
   def marginal(self, axis: int) -> jnp.ndarray:
     length = self.q.shape[0] if axis == 0 else self.r.shape[0]

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -141,8 +141,8 @@ class LRSinkhornOutput(NamedTuple):
   def apply(self, inputs: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
     """Applies the transport to a ndarray; axis=1 for its transpose."""
     q, r = (self.q, self.r) if axis == 1 else (self.r, self.q)
-    inputs = inputs.reshape(q.shape[0], -1)
-    return jnp.dot(q, jnp.dot(r.T, inputs) / self.g).squeeze()
+    inputs = inputs.reshape(r.shape[0], -1)
+    return jnp.dot(q, jnp.dot(r.T, inputs) / self.g.reshape(-1, 1)).squeeze()
 
   def marginal(self, axis: int) -> jnp.ndarray:
     length = self.q.shape[0] if axis == 0 else self.r.shape[0]

--- a/ott/core/sinkhorn_lr.py
+++ b/ott/core/sinkhorn_lr.py
@@ -141,7 +141,8 @@ class LRSinkhornOutput(NamedTuple):
   def apply(self, inputs: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
     """Applies the transport to a ndarray; axis=1 for its transpose."""
     q, r = (self.q, self.r) if axis == 1 else (self.r, self.q)
-    return jnp.dot(q, jnp.dot(r.T, inputs) / self.g)
+    inputs = inputs.reshape(q.shape[0], -1)
+    return jnp.dot(q, jnp.dot(r.T, inputs) / self.g).squeeze()
 
   def marginal(self, axis: int) -> jnp.ndarray:
     length = self.q.shape[0] if axis == 0 else self.r.shape[0]

--- a/tests/core/sinkhorn_lr_test.py
+++ b/tests/core/sinkhorn_lr_test.py
@@ -107,7 +107,8 @@ class SinkhornLRTest(parameterized.TestCase):
     self.assertGreater(cost_3, cost_2)
 
   @parameterized.parameters([0, 1])
-  def test_output_apply_multiple_sources(self, axis: int):
+  def test_output_apply_batch_size(self, axis: int):
+    n_stack = 3
     threshold = 1e-6
     data = self.a if axis == 0 else self.b
 
@@ -120,13 +121,12 @@ class SinkhornLRTest(parameterized.TestCase):
     )
     out = solver(ot_prob)
 
-    print(data.shape, axis, geom.shape, out.q.shape)
     gt = out.apply(data, axis=axis)
-    pred = out.apply(jnp.c_[data, data], axis=axis)
+    pred = out.apply(jnp.stack([data] * n_stack), axis=axis)
 
     self.assertEquals(gt.shape, (geom.shape[1 - axis],))
-    self.assertEquals(pred.shape, (geom.shape[1 - axis], 2))
-    np.testing.assert_allclose(pred, jnp.c_[gt, gt])
+    self.assertEquals(pred.shape, (n_stack, geom.shape[1 - axis]))
+    np.testing.assert_allclose(pred, jnp.stack([gt] * n_stack))
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
`SinkhornOutput.apply` accepts input of shape `(batch, features)` to be pushed/pull through the transport matrix.
This enables the same behavior for `LRSinkhornOutput.apply`