### PR TITLE
Fix LR Gromov memory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,12 @@ jobs:
       - uses: "actions/setup-python@v1"
         with:
             python-version: "${{ matrix.python-version }}"
-      - name: Install dependencies
-        run: |
-          set -xe
-          pip install --upgrade pip setuptools wheel
-          pip install -r requirements.txt
-          pip install pytest
-        shell: bash
       - name: Build
         run: |
           set -xe
           python -VV
-          pip install -e .
+          pip install --upgrade pip setuptools wheel
+          pip install -e '.[test]'
         shell: bash
       - name: Run tests
         run: |
@@ -39,5 +33,5 @@ jobs:
           python -VV
           python -c "import jax; print('jax', jax.__version__)"
           python -c "import jaxlib; print('jaxlib', jaxlib.__version__)"
-          pytest tests -v
+          pytest tests -v --memray
         shell: bash

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -152,7 +152,7 @@ class GromovWasserstein(was_solver.WassersteinSolver):
     gromov_fn = jax.jit(iterations_fn) if self.jit else iterations_fn
     out = gromov_fn(self, prob)
     # TODO(lpapaxanthos): remove stop_gradient when using backprop
-    if self.rank > 0:
+    if self.is_low_rank:
       linearization = prob.update_lr_linearization(
           jax.lax.stop_gradient(out.linear_state))
     else:

--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -468,14 +468,12 @@ class Geometry:
           lambda x: self._apply_cost_to_vec(x, axis, fn),
           1,
           1,
-      )(
-          arr.reshape(-1, 1))
+      )(arr.reshape(-1, 1))
     return jax.vmap(
         lambda x: self._apply_cost_to_vec(x, axis, fn),
         1,
         1,
-    )(
-        arr)
+    )(arr)
 
   def rescale_cost_fn(self, factor: float):
     if self._cost_matrix is not None:

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -151,9 +151,11 @@ class LRCGeometry(geometry.Geometry):
       out = jnp.dot(c1, jnp.dot(c2.T, vec))
       return out + bias * jnp.sum(vec) * jnp.ones_like(out)
 
-    return jnp.where(fn is None or geometry.is_linear(fn),
-                     efficient_apply(vec, axis, fn),
-                     super()._apply_cost_to_vec(vec, axis, fn))
+    return jax.lax.cond(
+      fn is None or geometry.is_linear(fn),
+      lambda _: efficient_apply(vec, axis, fn),
+      lambda obj: super(obj.__class__, obj)._apply_cost_to_vec(vec, axis, fn), self
+    )
 
   def compute_max_cost(self) -> float:
     """Computes the maximum of the cost matrix.

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -154,7 +154,8 @@ class LRCGeometry(geometry.Geometry):
     return jax.lax.cond(
       fn is None or geometry.is_linear(fn),
       lambda _: efficient_apply(vec, axis, fn),
-      lambda obj: super(obj.__class__, obj)._apply_cost_to_vec(vec, axis, fn), self
+      lambda obj: super(obj.__class__, obj)._apply_cost_to_vec(vec, axis, fn),
+      self
     )
 
   def compute_max_cost(self) -> float:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,5 @@ python_requires = >=3.7
 exclude =
     tests, docs, images
 
+[options.extras_require]
+test = absl-py; pytest; pytest-memray

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -258,11 +258,12 @@ class GromovWassersteinTest(parameterized.TestCase):
 
 
 # currently works only with `pytest`
-@pytest.mark.limit_memory("500 MB")
+# and musn't be placed in the class
+@pytest.mark.limit_memory("1 GB")
 def test_gw_lr_memory():
-  # Total memory allocated: 443.0MiB (32-bit)
+  # Total memory allocated: 925.2MiB (32-bit)
   rngs = jax.random.split(jax.random.PRNGKey(0), 2)
-  n, m, d1, d2 = 10_000, 10_000, 2, 3
+  n, m, d1, d2 = 15_000, 10_000, 2, 3
   x = jax.random.uniform(rngs[0], (n, d1))
   y = jax.random.uniform(rngs[1], (m, d2))
   geom_x = pointcloud.PointCloud(x)

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -258,7 +258,9 @@ class GromovWassersteinTest(parameterized.TestCase):
 
 
 # currently works only with `pytest`
-# and musn't be placed in the class
+# and mustn't be placed in the class
+# furthermore, can't be used atm with `pytest-xdist`
+# https://github.com/bloomberg/pytest-memray/issues/2
 @pytest.mark.limit_memory("1 GB")
 def test_gw_lr_memory():
   # Total memory allocated: 925.2MiB (32-bit)

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -16,6 +16,7 @@
 # Lint as: python3
 """Tests for the Gromov Wasserstein."""
 
+import pytest
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
@@ -254,6 +255,22 @@ class GromovWassersteinTest(parameterized.TestCase):
 
     np.testing.assert_allclose(pred.matrix, gt.matrix)
     np.testing.assert_allclose(pred.costs, gt.costs)
+
+
+# currently works only with `pytest`
+@pytest.mark.limit_memory("500 MB")
+def test_gw_lr_memory():
+  # Total memory allocated: 443.0MiB (32-bit)
+  rngs = jax.random.split(jax.random.PRNGKey(0), 2)
+  n, m, d1, d2 = 10_000, 10_000, 2, 3
+  x = jax.random.uniform(rngs[0], (n, d1))
+  y = jax.random.uniform(rngs[1], (m, d2))
+  geom_x = pointcloud.PointCloud(x)
+  geom_y = pointcloud.PointCloud(y)
+
+  ot_gwlr = gromov_wasserstein.gromov_wasserstein(geom_x, geom_y, rank=5, jit=False)
+
+  assert ot_gwlr.convergence
 
 
 if __name__ == '__main__':

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -271,7 +271,9 @@ def test_gw_lr_memory():
   geom_x = pointcloud.PointCloud(x)
   geom_y = pointcloud.PointCloud(y)
 
-  ot_gwlr = gromov_wasserstein.gromov_wasserstein(geom_x, geom_y, rank=5, jit=False)
+  ot_gwlr = gromov_wasserstein.gromov_wasserstein(
+    geom_x, geom_y, rank=5, jit=False
+  )
 
   assert ot_gwlr.convergence
 


### PR DESCRIPTION
Fixes memory complexity of LR gromov - problem was calling `jnp.where` and thus causing both
branches to be evaluated.
I've added a memory test for `n=15_000, m=10_000, r=5` (previously, the test consumed `1.7GB`, not it's `~970MiB` and updated the CI.
Furthermore, I've noticed an unusual (to me) behavior when passing `jit=True` in `GromovWasserstein`; am attaching a code to reproduce.
In short, jitting some function which takes geometries works, but they must be passed LR geometries.
Passing `jit=True` to the solver (which just jits the iteration loop) still causes memory issues (am unsure what causes this issue).

<details>

```python
from time import time
import ott
import numpy as np
import jax.numpy as jnp
import jax

from ott.geometry import pointcloud
from ott.core import quad_problems
from ott.core import problems
from ott.core import gromov_wasserstein
from ott.core.sinkhorn_lr import LRSinkhorn

rngs = jax.random.split(jax.random.PRNGKey(0), 4)
n, m, d1, d2 = 100_000, 100_000, 2, 3
x = jax.random.uniform(rngs[0], (n, d1))
y = jax.random.uniform(rngs[1], (m, d2))

geom_xx = pointcloud.PointCloud(x)
geom_xx_lr = geom_xx.to_LRCGeometry()
geom_yy = pointcloud.PointCloud(y)
geom_yy_lr = geom_yy.to_LRCGeometry()
prob = quad_problems.QuadraticProblem(geom_xx, geom_yy, scale_cost=None)

@jax.jit
def run(geom_xx, geom_yy):
    prob = quad_problems.QuadraticProblem(geom_xx, geom_yy)
    solver = gromov_wasserstein.GromovWasserstein(rank=10, epsilon=1e-2, jit=False)
    return solver(prob)

prob = quad_problems.QuadraticProblem(geom_xx, geom_yy)
solver = gromov_wasserstein.GromovWasserstein(
    rank=10, epsilon=1e-2, jit=False
)

# only run the JIT-ed version with LR geometries as input
t = time()
out_jit1 = run(geom_xx_lr, geom_yy_lr)
print(time() - t)  # 18.290289402008057

t = time()
out_jit2 = run(geom_xx_lr, geom_yy_lr)
print(time() - t)  # 5.751481294631958

# only run this if `jit=False` in `GromovWasserstein`
t = time()
out_njit = solver(prob)
print(time() - t)  # 19.70408797264099

print(out_jit1.reg_gw_cost, out_jit2.reg_gw_cost, out_njit.reg_gw_cost)
# 0.22205877 0.22205877 0.22205897
```

</details>