### PR TITLE
Fix `scale_cost` to LRGeometry, float/max-bound

### DIFF
--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -94,12 +94,14 @@ class LRCGeometry(geometry.Geometry):
   @property
   def scale_cost(self):
     if isinstance(self._scale_cost, float):
-      return self._scale_cost
+      return 1.0 / self._scale_cost
     elif self._scale_cost == 'max_bound':
-      return jax.lax.stop_gradient(
-          1.0 / (jnp.max(jnp.abs(self._cost_1))
-                 * jnp.max(jnp.abs(self._cost_2))
-                 + self._bias))
+      x_norm = self._cost_1[:, 0].max()
+      y_norm = self._cost_2[:, 1].max()
+      max_bound = x_norm + y_norm + 2 * jnp.sqrt(
+        x_norm * y_norm
+      )
+      return jax.lax.stop_gradient(1.0 / (max_bound + self._bias))
     elif self._scale_cost == 'mean':
       factor1 = jnp.dot(jnp.ones(self.shape[0]), self._cost_1)
       factor2 = jnp.dot(self._cost_2.T, jnp.ones(self.shape[1]))

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -516,6 +516,7 @@ class PointCloud(geometry.Geometry):
             epsilon=self._epsilon_init,
             relative_epsilon=self._relative_epsilon,
             scale=self._scale_epsilon,
+            scale_cost=self._scale_cost,
             **self._kwargs)
       else:
         self.x *= jnp.sqrt(scale)


### PR DESCRIPTION
Fixes the following:
- not passing `scale_cost` when creating `LRCGeometry` from `PointCloud`
- `float` scale cost in `LRCGeometry`
- `'max_bound'` scale cost in `LRCGeometry` (slightly unsure about this)

I've parametrized 1 existing test and added checks for this.