### PR TITLE
Fix/lr linear apply

### DIFF
--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -335,7 +335,7 @@ def gromov_wasserstein(
     scale_cost: Optional[Union[bool, float, str]] = False,
     a: Optional[jnp.ndarray] = None,
     b: Optional[jnp.ndarray] = None,
-    loss: Union[Literal['sqeucl', 'kl'], quad_problems.Loss] = 'sqeucl',
+    loss: Union[Literal['sqeucl', 'kl'], quad_problems.GWLoss] = 'sqeucl',
     tau_a: Optional[float] = 1.0,
     tau_b: Optional[float] = 1.0,
     gw_unbalanced_correction: bool = True,

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -539,4 +539,4 @@ def apply_cost(
     geom: geometry.Geometry, arr: jnp.ndarray, *, axis: int, fn: Loss
 ) -> jnp.ndarray:
   # TODO(michalk8): handle PCs
-  return geom.apply_cost(arr, axis=axis, fn=fn.func, is_linear=fn.is_linear)
+  return geom.apply_cost(arr, axis=axis, fn=fn.func, is_linear=None)

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Classes defining OT problem(s) (objective function + utilities)."""
 
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, NamedTuple, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -43,19 +43,32 @@ class Transport(Protocol):
     ...
 
 
-LossTerm = Callable[[jnp.ndarray], jnp.ndarray]
-Loss = Tuple[Tuple[LossTerm, LossTerm], Tuple[LossTerm, LossTerm]]
+class Loss(NamedTuple):
+  func: Callable[[jnp.ndarray], jnp.ndarray]
+  is_linear: bool
 
 
-# TODO(michalk8): make nicer abstraction
-def make_square_loss() -> Loss:
-  return ((lambda x: x ** 2, lambda y: y ** 2),
-          (lambda x: x, lambda y: 2.0 * y))
+class GWLoss(NamedTuple):
+  f1: Loss
+  f2: Loss
+  h1: Loss
+  h2: Loss
 
 
-def make_kl_loss(clipping_value: float = 1e-8) -> Loss:
-  return ((lambda x: -jax.scipy.special.entr(x) - x, lambda y: y),
-          (lambda x: x, lambda y: jnp.log(jnp.clip(y, clipping_value))))
+def make_square_loss() -> GWLoss:
+  f1 = Loss(lambda x: x ** 2, is_linear=False)
+  f2 = Loss(lambda y: y ** 2, is_linear=False)
+  h1 = Loss(lambda x: x, is_linear=True)
+  h2 = Loss(lambda y: 2.0 * y, is_linear=True)
+  return GWLoss(f1, f2, h1, h2)
+
+
+def make_kl_loss(clipping_value: float = 1e-8) -> GWLoss:
+  f1 = Loss(lambda x: -jax.scipy.special.entr(x) - x, is_linear=False)
+  f2 = Loss(lambda y: y, is_linear=True)
+  h1 = Loss(lambda x: x, is_linear=True)
+  h2 = Loss(lambda y: jnp.log(jnp.clip(y, clipping_value)), is_linear=False)
+  return GWLoss(f1, f2, h1, h2)
 
 
 @jax.tree_util.register_pytree_node_class
@@ -121,7 +134,7 @@ class QuadraticProblem:
       scale_cost: Optional[Union[bool, float, str]] = False,
       a: Optional[jnp.ndarray] = None,
       b: Optional[jnp.ndarray] = None,
-      loss: Union[Literal['sqeucl', 'kl'], Loss] = 'sqeucl',
+      loss: Union[Literal['sqeucl', 'kl'], GWLoss] = 'sqeucl',
       tau_a: Optional[float] = 1.0,
       tau_b: Optional[float] = 1.0,
       gw_unbalanced_correction: bool = True
@@ -161,12 +174,12 @@ class QuadraticProblem:
     )
 
   @property
-  def linear_loss(self) -> Tuple[LossTerm, LossTerm]:
-    return self.loss[0]
+  def linear_loss(self) -> Tuple[Loss, Loss]:
+    return self.loss.f1, self.loss.f2
 
   @property
-  def quad_loss(self) -> Tuple[LossTerm, LossTerm]:
-    return self.loss[1]
+  def quad_loss(self) -> Tuple[Loss, Loss]:
+    return self.loss.h1, self.loss.h2
 
   @property
   def is_balanced(self) -> bool:
@@ -228,8 +241,9 @@ class QuadraticProblem:
       tmp1 = self.geom_xx.apply_square_cost(marginal_1, axis=1)
       tmp2 = self.geom_yy.apply_square_cost(marginal_2, axis=1)
     else:
-      tmp1 = self.geom_xx.apply_cost(marginal_1, axis=1, fn=self.linear_loss[0])
-      tmp2 = self.geom_yy.apply_cost(marginal_2, axis=1, fn=self.linear_loss[1])
+      f1, f2 = self.linear_loss
+      tmp1 = apply_cost(self.geom_xx, marginal_1, axis=1, fn=f1)
+      tmp2 = apply_cost(self.geom_yy, marginal_2, axis=1, fn=f2)
     x_term = jnp.concatenate((tmp1, jnp.ones_like(tmp1)), axis=1)
     y_term = jnp.concatenate((jnp.ones_like(tmp2), tmp2), axis=1)
     return low_rank.LRCGeometry(cost_1=x_term, cost_2=y_term)
@@ -370,8 +384,9 @@ class QuadraticProblem:
           tmp, marginal_1, marginal_2, epsilon, 1.0
       )
 
-    tmp = self.geom_xx.apply_cost(tmp, axis=1, fn=self.quad_loss[0])
-    tmp = self.geom_yy.apply_cost(tmp.T, axis=1, fn=self.quad_loss[1]).T
+    h1, h2 = self.quad_loss
+    tmp = apply_cost(self.geom_xx, tmp, axis=1, fn=h1)
+    tmp = apply_cost(self.geom_yy, tmp.T, axis=1, fn=h2).T
     cost_matrix = (marginal_cost.cost_matrix - tmp + unbalanced_correction)
 
     # Initialises epsilon for Unbalanced GW according to Sejourne et al (2021).
@@ -420,8 +435,9 @@ class QuadraticProblem:
     q, r = q * inv_sqg[None, :], r * inv_sqg[None, :]
 
     # Handle LRC Geometry case.
-    tmp1 = self.geom_xx.apply_cost(q, axis=1, fn=self.quad_loss[0])
-    tmp2 = self.geom_yy.apply_cost(r, axis=1, fn=self.quad_loss[1])
+    h1, h2 = self.quad_loss
+    tmp1 = apply_cost(self.geom_xx, q, axis=1, fn=h1)
+    tmp2 = apply_cost(self.geom_yy, r, axis=1, fn=h2)
     if self.is_all_geoms_lr:
       geom = low_rank.LRCGeometry(cost_1=tmp1, cost_2=-tmp2)
       geom = low_rank.add_lrc_geom(geom, marginal_cost)
@@ -475,10 +491,9 @@ class QuadraticProblem:
       # Updates epsilon for Unbalanced GW.
       epsilon = update_epsilon_unbalanced(epsilon, transport_mass)
 
-    tmp = self.geom_xx.apply_cost(
-        transport.matrix, axis=1, fn=self.quad_loss[0]
-    )
-    tmp = self.geom_yy.apply_cost(tmp.T, axis=1, fn=self.quad_loss[1]).T
+    h1, h2 = self.quad_loss
+    tmp = apply_cost(self.geom_xx, transport.matrix, axis=1, fn=h1)
+    tmp = apply_cost(self.geom_yy, tmp.T, axis=1, fn=h2).T
 
     cost_matrix = marginal_cost.cost_matrix - tmp + unbalanced_correction
     cost_matrix += self.fused_penalty * self._fused_cost_matrix
@@ -518,3 +533,10 @@ def update_epsilon_unbalanced(epsilon, transport_mass):
       updated_epsilon._scale_epsilon * transport_mass
   )
   return updated_epsilon
+
+
+def apply_cost(
+    geom: geometry.Geometry, arr: jnp.ndarray, *, axis: int, fn: Loss
+) -> jnp.ndarray:
+  # TODO(michalk8): handle PCs
+  return geom.apply_cost(arr, axis=axis, fn=fn.func, is_linear=fn.is_linear)

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -539,4 +539,4 @@ def apply_cost(
     geom: geometry.Geometry, arr: jnp.ndarray, *, axis: int, fn: Loss
 ) -> jnp.ndarray:
   # TODO(michalk8): handle PCs
-  return geom.apply_cost(arr, axis=axis, fn=fn.func, is_linear=None)
+  return geom.apply_cost(arr, axis=axis, fn=fn.func, is_linear=fn.is_linear)

--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -530,7 +530,13 @@ class Geometry:
     fn = lambda x: x ** 2
     return self.apply_cost(arr, axis, fn)
 
-  def apply_cost(self, arr: jnp.ndarray, axis: int = 0, fn=None) -> jnp.ndarray:
+  def apply_cost(
+      self,
+      arr: jnp.ndarray,
+      axis: int = 0,
+      fn=None,
+      **kwargs: Any
+  ) -> jnp.ndarray:
     """Apply cost matrix to array (vector or matrix).
 
     This function applies the ground geometry's cost matrix, to perform either
@@ -543,20 +549,21 @@ class Geometry:
         the cost matrix.
       axis: standard cost matrix if axis=1, transpose if 0
       fn: function to apply to cost matrix element-wise before the dot product
+      kwargs: Keyword arguments for :meth:`_apply_cost_to_vec`.
 
     Returns:
       An array, [num_b, p] if axis=0 or [num_a, p] if axis=1
     """
     if arr.ndim == 1:
       return jax.vmap(
-          lambda x: self._apply_cost_to_vec(x, axis, fn),
+          lambda x: self._apply_cost_to_vec(x, axis, fn, **kwargs),
           1,
           1,
       )(
           arr.reshape(-1, 1)
       )
     return jax.vmap(
-        lambda x: self._apply_cost_to_vec(x, axis, fn),
+        lambda x: self._apply_cost_to_vec(x, axis, fn, **kwargs),
         1,
         1,
     )(
@@ -579,7 +586,11 @@ class Geometry:
       self._kernel_matrix **= 1 / factor
 
   def _apply_cost_to_vec(
-      self, vec: jnp.ndarray, axis: int = 0, fn=None
+      self,
+      vec: jnp.ndarray,
+      axis: int = 0,
+      fn=None,
+      **_: Any,
   ) -> jnp.ndarray:
     """Apply [num_a, num_b] fn(cost) (or transpose) to vector.
 

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -140,7 +140,7 @@ class LRCGeometry(geometry.Geometry):
       vec: jnp.ndarray,
       axis: int = 0,
       fn: Optional[Callable[[jnp.ndarray], jnp.ndarray]] = None,
-      is_linear: bool = False,
+      is_linear: Optional[bool] = None,
   ) -> jnp.ndarray:
     """Apply [num_a, num_b] fn(cost) (or transpose) to vector.
 
@@ -150,8 +150,8 @@ class LRCGeometry(geometry.Geometry):
       fn: function optionally applied to cost matrix element-wise, before the
         doc product
       is_linear: Whether ``fn`` is a linear function. If yes, efficient
-        implementation is used. See :func:`ott.geometry.geometry.is_linear`
-        for a heuristic that can help determine whether a function is linear.
+        implementation is used. If ``None``, it will be determined by
+        :func:`ott.geometry.geometry.is_linear` at runtime.
 
     Returns:
       A jnp.ndarray corresponding to cost x vector
@@ -169,7 +169,17 @@ class LRCGeometry(geometry.Geometry):
 
     if fn is None or is_linear:
       return linear_apply(vec, axis, fn)
-    return super()._apply_cost_to_vec(vec, axis, fn)
+
+    # TODO(michalk8): for bwd compatibility only, should be removed once
+    # same principle is used in `LRSinkhorn` and `PointCloud`
+    # yapf: disable
+    return jax.lax.cond(
+        geometry.is_linear(fn),
+        lambda _: linear_apply(vec, axis, fn),
+        lambda g: super(g.__class__, g)._apply_cost_to_vec(vec, axis, fn),
+        self
+    )
+    # yapf: enable
 
   def compute_max_cost(self) -> float:
     """Compute the maximum of the cost matrix.

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -14,7 +14,7 @@
 
 # Lint as: python3
 """A class describing low-rank geometries."""
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -136,7 +136,11 @@ class LRCGeometry(geometry.Geometry):
       ).apply_cost(arr, axis)
 
   def _apply_cost_to_vec(
-      self, vec: jnp.ndarray, axis: int = 0, fn=None
+      self,
+      vec: jnp.ndarray,
+      axis: int = 0,
+      fn: Optional[Callable[[jnp.ndarray], jnp.ndarray]] = None,
+      is_linear: bool = False,
   ) -> jnp.ndarray:
     """Apply [num_a, num_b] fn(cost) (or transpose) to vector.
 
@@ -145,12 +149,17 @@ class LRCGeometry(geometry.Geometry):
       axis: axis on which the reduction is done.
       fn: function optionally applied to cost matrix element-wise, before the
         doc product
+      is_linear: Whether ``fn`` is a linear function. If yes, efficient
+        implementation is used. See :func:`ott.geometry.geometry.is_linear`
+        for a heuristic that can help determine whether a function is linear.
 
     Returns:
       A jnp.ndarray corresponding to cost x vector
     """
 
-    def efficient_apply(vec, axis, fn):
+    def linear_apply(
+        vec: jnp.ndarray, axis: int, fn: Callable[[jnp.ndarray], jnp.ndarray]
+    ) -> jnp.ndarray:
       c1 = self.cost_1 if axis == 1 else self.cost_2
       c2 = self.cost_2 if axis == 1 else self.cost_1
       c2 = fn(c2) if fn is not None else c2
@@ -158,12 +167,9 @@ class LRCGeometry(geometry.Geometry):
       out = jnp.dot(c1, jnp.dot(c2.T, vec))
       return out + bias * jnp.sum(vec) * jnp.ones_like(out)
 
-    return jax.lax.cond(
-        fn is None or geometry.is_linear(fn),
-        lambda _: efficient_apply(vec, axis, fn),
-        lambda obj: super(obj.__class__, obj)._apply_cost_to_vec(vec, axis, fn),
-        self
-    )
+    if fn is None or is_linear:
+      return linear_apply(vec, axis, fn)
+    return super()._apply_cost_to_vec(vec, axis, fn)
 
   def compute_max_cost(self) -> float:
     """Compute the maximum of the cost matrix.

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -351,7 +351,9 @@ class PointCloud(geometry.Geometry):
         self._cost_fn, self.power, self.inv_scale_cost
     )
 
-  def apply_cost(self, arr: jnp.ndarray, axis: int = 0, fn=None) -> jnp.ndarray:
+  def apply_cost(
+      self, arr: jnp.ndarray, axis: int = 0, fn=None, **_: Any
+  ) -> jnp.ndarray:
     """Apply cost matrix to array (vector or matrix).
 
     This function applies the geometry's cost matrix, to perform either

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -18,7 +18,6 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pytest
 from absl.testing import absltest, parameterized
 
 from ott.core import gromov_wasserstein, quad_problems
@@ -317,27 +316,6 @@ class GromovWassersteinTest(parameterized.TestCase):
 
     np.testing.assert_allclose(pred.matrix, gt.matrix)
     np.testing.assert_allclose(pred.costs, gt.costs)
-
-
-# currently works only with `pytest`
-# and mustn't be placed in the class
-# furthermore, can't be used atm with `pytest-xdist`
-# https://github.com/bloomberg/pytest-memray/issues/2
-@pytest.mark.limit_memory("1 GB")
-def test_gw_lr_memory():
-  # Total memory allocated: 925.2MiB (32-bit)
-  rngs = jax.random.split(jax.random.PRNGKey(0), 2)
-  n, m, d1, d2 = 15_000, 10_000, 2, 3
-  x = jax.random.uniform(rngs[0], (n, d1))
-  y = jax.random.uniform(rngs[1], (m, d2))
-  geom_x = pointcloud.PointCloud(x)
-  geom_y = pointcloud.PointCloud(y)
-
-  ot_gwlr = gromov_wasserstein.gromov_wasserstein(
-      geom_x, geom_y, rank=5, jit=False
-  )
-
-  assert ot_gwlr.convergence
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-up of #88 

Require the know whether `fn` is linear at compile time for more efficient implementation.
I wasn't able to find a better solution which would maintain the `jax.lax.cond`, but I also slightly disliked the heuristic.
I've tried to figure out why the OOM exactly happens, as the inefficient branch shouldn't even be executed, I suspect it's either because the `_apply_cost_to_vec` is inside a `vmap` (https://github.com/google/jax/discussions/9543#discussioncomment-2160988) or because there was no data dependence between the condition and the branches (https://github.com/google/jax/issues/3103#issuecomment-629579810 - I've tried different branching arguments + `cond over vmap` instead of `vmap over cond`, didn't help).
Now in case of GW, the squared Eucl./KL's components are manually annotated whether they are linear or not (don't think is too much hassle for the user + more robust than the current check).

I've kept the `jax.lax.cond` as default when `is_linear=None` for compatibility with `LRSinkhorn`, which will be fixed in a future PR.
Furthermore, same issue occurs in `PointCloud` [here](https://github.com/ott-jax/ott/blob/main/ott/geometry/pointcloud.py#L376-L380), see also the snippet below. This would require annotating the costs in `ott.geometry.costs`, which I think should also be done in a future PR.

Below is a small testing snippet, the current memory test for GW has been modified to FGW and passes with even lower memory:
```python
from jax.config import config
config.update("jax_enable_x64", True)

import ott
import numpy as np
import jax.numpy as jnp

n = 300_000
d = 30
epsilon = 1e-2
np.random.seed(42)

x = jnp.asarray(np.random.normal(size=(n, d)))
geom_x = ott.geometry.pointcloud.PointCloud(x, epsilon=epsilon)
geom_x_lrc = geom_x.to_LRCGeometry()

# `geom_x.apply_cost` fails with:
# XlaRuntimeError: RESOURCE_EXHAUSTED: Out of memory allocating 1440000000048 bytes.
gt = geom_x.vec_apply_cost(x[:, 0], fn=lambda x: x * 10)
# `geom_x_lrc.apply_cost` with `is_linear=None` fails with:
# XlaRuntimeError: RESOURCE_EXHAUSTED: Out of memory allocating 720000000072 bytes.
pred = geom_x_lrc.apply_cost(x[:, 0], fn=lambda x: x * 10, is_linear=True)
assert jnp.allclose(gt, pred)
```

`jax/jaxlib` versions: '0.3.13', '0.3.10'