### PR TITLE
GW different cost ranks

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -44,7 +44,8 @@
   publisher =  {PMLR},
   pdf = {http://proceedings.mlr.press/v32/cuturi14.pdf},
   url = {https://proceedings.mlr.press/v32/cuturi14.html},
-}:
+}
+
 @InProceedings{indyk:19,
  title = {Sample-Optimal Low-Rank Approximation of Distance Matrices},
  author = {Indyk, Pitor and Vakilian, Ali and Wagner, Tal and Woodruff, David P},
@@ -107,22 +108,6 @@
  issn = "1615-3383",
  doi = "10.1007/s10208-011-9093-5",
  url = "https://doi.org/10.1007/s10208-011-9093-5"
-}
-
-@InProceedings{peyre:16,
- title = {Gromov-Wasserstein Averaging of Kernel and Distance Matrices},
- author = {Peyré, Gabriel and Cuturi, Marco and Solomon, Justin},
- booktitle = {Proceedings of The 33rd International Conference on Machine Learning},
- pages = {2664--2672},
- year = {2016},
- editor = {Balcan, Maria Florina and Weinberger, Kilian Q.},
- volume = {48},
- series = {Proceedings of Machine Learning Research},
- address = {New York, New York, USA},
- month = {20--22 Jun},
- publisher = {PMLR},
- pdf = {http://proceedings.mlr.press/v48/peyre16.pdf},
- url = {https://proceedings.mlr.press/v48/peyre16.html},
 }
 
 @InProceedings{scetbon:22,

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -140,7 +140,7 @@ class GromovWasserstein(was_solver.WassersteinSolver):
 
   def __call__(self, prob: quad_problems.QuadraticProblem) -> GWOutput:
     # consider converting problem first if using low-rank solver
-    if self.is_low_rank and prob._should_convert_to_low_rank:
+    if self.is_low_rank and prob._is_low_rank_convertible:
       prob = prob.to_low_rank()
 
     # Possibly jit iteration functions and run. Closure on rank to

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -355,7 +355,7 @@ def gromov_wasserstein(
     b: jnp.ndarray<float>[num_b,] or jnp.ndarray<float>[batch,num_b] weights.
     loss: defaults to the square Euclidean distance. Can also pass 'kl'
       to define the GW loss as KL loss.
-      See :class:`ott.core.gromov_wasserstein.GromovWasserstein` on how to pass
+      See :class:`~ott.core.gromov_wasserstein.GromovWasserstein` on how to pass
       custom loss.
     tau_a: float between 0 and 1.0, parameter that controls the strength of the
       KL divergence constraint between the weights and marginals of the
@@ -366,13 +366,15 @@ def gromov_wasserstein(
       transport for the second view. If set to 1.0, then it is equivalent to a
       hard constraint and if smaller to a softer constraint.
     gw_unbalanced_correction: True (default) if the unbalanced version of
-      Sejourne et al (Neurips 2021) is used, False if tau_a and tau_b
-      only affect the inner Sinhkorn loop.
+      :cite:`sejourne:21` is used, False if tau_a and tau_b
+      only affect the inner Sinkhorn loop.
     ranks: Ranks of the cost matrices, see
       :meth:`~ott.geometry.geometry.Geometry.to_LRCGeometry`. Used when
       geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
       `'sqeucl'` cost function. If `-1`, the geometries will not be converted
-      to low-rank. If :class:`int`, rank shared across all geometries.
+      to low-rank. If :class:`tuple`, it specifies the ranks of ``geom_xx``,
+      ``geom_yy`` and ``geom_xy``, respectively. If :class:`int`, rank is shared
+      across all geometries.
     tolerances: Tolerances used when converting geometries to low-rank. Used when
       geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
       `'sqeucl'` cost. If :class:`float`, it is shared across all geometries.

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -15,7 +15,7 @@
 # Lint as: python3
 """A Jax version of the regularised GW Solver (Peyre et al. 2016)."""
 import functools
-from typing import Any, Dict, NamedTuple, Optional, Union
+from typing import Any, Dict, NamedTuple, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -326,6 +326,8 @@ def gromov_wasserstein(
     tau_a: Optional[float] = 1.0,
     tau_b: Optional[float] = 1.0,
     gw_unbalanced_correction: bool = True,
+    ranks: Union[int, Tuple[int, ...]] = -1,
+    tolerances: Union[float, Tuple[float, ...]] = 1e-2,
     **kwargs: Any,
 ) -> GWOutput:
   """Solve a Gromov Wasserstein problem.
@@ -366,6 +368,14 @@ def gromov_wasserstein(
     gw_unbalanced_correction: True (default) if the unbalanced version of
       Sejourne et al (Neurips 2021) is used, False if tau_a and tau_b
       only affect the inner Sinhkorn loop.
+    ranks: Ranks of the cost matrices, see
+      :meth:`~ott.geometry.geometry.Geometry.to_LRCGeometry`. Used when
+      geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
+      `'sqeucl'` cost function. If `-1`, the geometries will not be converted
+      to low-rank. If :class:`int`, rank shared across all geometries.
+    tolerances: Tolerances used when converting geometries to low-rank. Used when
+      geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
+      `'sqeucl'` cost. If :class:`float`, it is shared across all geometries.
     kwargs: keyword arguments to make.
 
   Returns:
@@ -382,7 +392,9 @@ def gromov_wasserstein(
       loss=loss,
       tau_a=tau_a,
       tau_b=tau_b,
-      gw_unbalanced_correction=gw_unbalanced_correction
+      gw_unbalanced_correction=gw_unbalanced_correction,
+      ranks=ranks,
+      tolerances=tolerances
   )
   solver = make(**kwargs)
   return solver(prob)

--- a/ott/core/linear_problems.py
+++ b/ott/core/linear_problems.py
@@ -52,7 +52,6 @@ class LinearProblem:
       tau_a: float = 1.0,
       tau_b: float = 1.0
   ):
-
     self.geom = geom
     self._a = a
     self._b = b

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -540,7 +540,7 @@ class QuadraticProblem:
     return self.geom_xy.cost_matrix
 
   @property
-  def _should_convert_to_low_rank(self) -> bool:
+  def _is_low_rank_convertible(self) -> bool:
 
     def convertible(geom: geometry.Geometry) -> bool:
       return isinstance(geom, low_rank.LRCGeometry) or (
@@ -548,11 +548,11 @@ class QuadraticProblem:
       )
 
     if self.is_low_rank:
-      return False
+      return True
 
     geom_xx, geom_yy, geom_xy = self.geom_xx, self.geom_yy, self.geom_xy
-    # either explicitly requested or implicitly convertible
-    return self.ranks != -1 or (
+    # either explicitly via cost factorization or implicitly (e.g., a PC)
+    return self.ranks != 1 or (
         convertible(geom_xx) and convertible(geom_yy) and
         (geom_xy is None or convertible(geom_xy))
     )

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -121,6 +121,14 @@ class QuadraticProblem:
     gw_unbalanced_correction: True (default) if the unbalanced version of
       Sejourne et al. (Neurips 2021) is used, False if tau_a and tau_b
       only affect the inner Sinhkorn loop.
+    ranks: Ranks of the cost matrices, see
+      :meth:`~ott.geometry.geometry.Geometry.to_LRCGeometry`. Used when
+      geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
+      `'sqeucl'` cost function. If `-1`, the geometries will not be converted
+      to low-rank. If :class:`int`, rank shared across all geometries.
+    tolerances: Tolerances used when converting geometries to low-rank. Used when
+      geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
+      `'sqeucl'` cost. If :class:`float`, it is shared across all geometries.
   """
 
   def __init__(
@@ -135,7 +143,9 @@ class QuadraticProblem:
       loss: Union[Literal['sqeucl', 'kl'], GWLoss] = 'sqeucl',
       tau_a: Optional[float] = 1.0,
       tau_b: Optional[float] = 1.0,
-      gw_unbalanced_correction: bool = True
+      gw_unbalanced_correction: bool = True,
+      ranks: Union[int, Tuple[int, ...]] = -1,
+      tolerances: Union[float, Tuple[float, ...]] = 1e-2,
   ):
     assert fused_penalty > 0, fused_penalty
     self.geom_xx = geom_xx._set_scale_cost(scale_cost)
@@ -150,6 +160,8 @@ class QuadraticProblem:
     self.tau_a = tau_a
     self.tau_b = tau_b
     self.gw_unbalanced_correction = gw_unbalanced_correction
+    self.ranks = ranks
+    self.tolerances = tolerances
 
     self._loss_name = loss
     if self._loss_name == 'sqeucl':
@@ -164,11 +176,13 @@ class QuadraticProblem:
     return self.geom_xy is not None
 
   @property
-  def is_all_geoms_lr(self) -> bool:
+  def is_low_rank(self) -> bool:
     return (
         isinstance(self.geom_xx, low_rank.LRCGeometry) and
-        isinstance(self.geom_yy, low_rank.LRCGeometry) and
-        isinstance(self.geom_xy, (low_rank.LRCGeometry, type(None)))
+        isinstance(self.geom_yy, low_rank.LRCGeometry) and (
+            self.geom_xy is None or
+            isinstance(self.geom_xy, low_rank.LRCGeometry)
+        )
     )
 
   @property
@@ -191,7 +205,9 @@ class QuadraticProblem:
         'loss': self._loss_name,
         'fused_penalty': self.fused_penalty,
         'scale_cost': self.scale_cost,
-        'gw_unbalanced_correction': self.gw_unbalanced_correction
+        'gw_unbalanced_correction': self.gw_unbalanced_correction,
+        'ranks': self.ranks,
+        'tolerances': self.tolerances
     })
 
   @classmethod
@@ -434,7 +450,7 @@ class QuadraticProblem:
     h1, h2 = self.quad_loss
     tmp1 = apply_cost(self.geom_xx, q, axis=1, fn=h1)
     tmp2 = apply_cost(self.geom_yy, r, axis=1, fn=h2)
-    if self.is_all_geoms_lr:
+    if self.is_low_rank:
       geom = low_rank.LRCGeometry(cost_1=tmp1, cost_2=-tmp2)
       geom = low_rank.add_lrc_geom(geom, marginal_cost)
       if self.is_fused:
@@ -516,12 +532,69 @@ class QuadraticProblem:
   @property
   def _fused_cost_matrix(self) -> Union[float, jnp.ndarray]:
     if not self.is_fused:
-      return 0
+      return 0.
     if isinstance(
         self.geom_xy, pointcloud.PointCloud
     ) and self.geom_xy.is_online:
       return self.geom_xy.compute_cost_matrix() * self.geom_xy.inv_scale_cost
     return self.geom_xy.cost_matrix
+
+  @property
+  def _should_convert_to_low_rank(self) -> bool:
+
+    def is_sqeucl_pc(geom: geometry.Geometry) -> bool:
+      return isinstance(
+          geom, pointcloud.PointCloud
+      ) and geom.is_squared_euclidean
+
+    if self.is_low_rank:
+      return False
+
+    geom_xx, geom_yy, geom_xy = self.geom_xx, self.geom_yy, self.geom_xy
+    return self.ranks != -1 or (
+        is_sqeucl_pc(geom_xx) and is_sqeucl_pc(geom_yy) and
+        (geom_xy is None or is_sqeucl_pc(geom_xy))
+    )
+
+  def to_low_rank(self, seed: int = 0) -> "QuadraticProblem":
+    """Convert geometries to low-rank.
+
+    Args:
+      seed: Random seed.
+
+    Returns:
+      Quadratic problem with low-rank geometries.
+    """
+
+    def convert(
+        vals: Union[int, float, Tuple[Union[int, float], ...]]
+    ) -> Tuple[Union[int, float], ...]:
+      size = 2 + self.is_fused
+      if isinstance(vals, (int, float)):
+        return (vals,) * size
+      assert len(vals) == size, vals
+      return vals + (None,) * (3 - size)
+
+    if self.is_low_rank:
+      return self
+
+    (geom_xx, geom_yy, geom_xy, *children), aux_data = self.tree_flatten()
+    (s1, s2, s3) = jax.random.split(jax.random.PRNGKey(seed), 3)[:, 0]
+    (r1, r2, r3), (t1, t2, t3) = convert(self.ranks), convert(self.tolerances)
+
+    geom_xx = geom_xx.to_LRCGeometry(rank=r1, tol=t1, seed=s1)
+    geom_yy = geom_yy.to_LRCGeometry(rank=r2, tol=t2, seed=s2)
+    if self.is_fused:
+      if isinstance(
+          geom_xy, pointcloud.PointCloud
+      ) and geom_xy.is_squared_euclidean:
+        geom_xy = geom_xy.to_LRCGeometry(self.fused_penalty)
+      else:
+        geom_xy = geom_xy.to_LRCGeometry(rank=r3, tol=t3, seed=s3)
+
+    return type(self).tree_unflatten(
+        aux_data, [geom_xx, geom_yy, geom_xy] + children
+    )
 
 
 def update_epsilon_unbalanced(epsilon, transport_mass):

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -571,7 +571,7 @@ class QuadraticProblem:
     ) -> Tuple[Union[int, float], ...]:
       size = 2 + self.is_fused
       if isinstance(vals, (int, float)):
-        return (vals,) * size
+        return (vals,) * 3
       assert len(vals) == size, vals
       return vals + (None,) * (3 - size)
 

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -119,13 +119,15 @@ class QuadraticProblem:
     tau_b: if lower that 1.0, defines how much unbalanced the problem is on
       the second marginal.
     gw_unbalanced_correction: True (default) if the unbalanced version of
-      Sejourne et al. (Neurips 2021) is used, False if tau_a and tau_b
-      only affect the inner Sinhkorn loop.
+      :cite:`sejourne:21` is used, False if tau_a and tau_b
+      only affect the inner Sinkhorn loop.
     ranks: Ranks of the cost matrices, see
       :meth:`~ott.geometry.geometry.Geometry.to_LRCGeometry`. Used when
       geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
       `'sqeucl'` cost function. If `-1`, the geometries will not be converted
-      to low-rank. If :class:`int`, rank shared across all geometries.
+      to low-rank. If :class:`tuple`, it specifies the ranks of ``geom_xx``,
+      ``geom_yy`` and ``geom_xy``, respectively. If :class:`int`, rank is shared
+      across all geometries.
     tolerances: Tolerances used when converting geometries to low-rank. Used when
       geometries are *not* :class:`~ott.geometry.pointcloud.PointCloud` with
       `'sqeucl'` cost. If :class:`float`, it is shared across all geometries.

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -542,18 +542,19 @@ class QuadraticProblem:
   @property
   def _should_convert_to_low_rank(self) -> bool:
 
-    def is_sqeucl_pc(geom: geometry.Geometry) -> bool:
-      return isinstance(
-          geom, pointcloud.PointCloud
-      ) and geom.is_squared_euclidean
+    def convertible(geom: geometry.Geometry) -> bool:
+      return isinstance(geom, low_rank.LRCGeometry) or (
+          isinstance(geom, pointcloud.PointCloud) and geom.is_squared_euclidean
+      )
 
     if self.is_low_rank:
       return False
 
     geom_xx, geom_yy, geom_xy = self.geom_xx, self.geom_yy, self.geom_xy
+    # either explicitly requested or implicitly convertible
     return self.ranks != -1 or (
-        is_sqeucl_pc(geom_xx) and is_sqeucl_pc(geom_yy) and
-        (geom_xy is None or is_sqeucl_pc(geom_xy))
+        convertible(geom_xx) and convertible(geom_yy) and
+        (geom_xy is None or convertible(geom_xy))
     )
 
   def to_low_rank(self, seed: int = 0) -> "QuadraticProblem":

--- a/ott/core/segment.py
+++ b/ott/core/segment.py
@@ -42,7 +42,15 @@ def segment_point_cloud(
   upper bound on the maximal size of measures, which will be used for padding.
 
   Args:
-    TODO.
+    y: a matrix merging the points of all measures.
+    a: a vector containing the weights (within each measure) of all the points.
+    segment_ids: describe for each point to which measure it belongs.
+    num_segments: total number of measures.
+    indices_are_sorted: flag indicating indices in segment_ids are sorted.
+    num_per_segment: number of points in each segment, if contiguous.
+    max_measure_size: max number of points in each segment (for efficient jit)
+    padding_vector: Vector of shape ``[1, dim]`` used for padding.
+      If ``None``, use a vector of 0s.
 
   Returns:
     Segmented ``x``, ``y`` and the number segments.

--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -679,9 +679,8 @@ class Geometry:
     U = U[:, :rank]  # (n_subset, rank)
     U = (S.T @ U) / jnp.linalg.norm(W.T @ U, axis=0)  # (m, rank)
 
-    # lls
-    d, v = jnp.linalg.eigh(U.T @ U)  # (k,), (k, k)
-    v /= jnp.sqrt(d)[None, :]
+    _, d, v = jnp.linalg.svd(U.T @ U)  # (k,), (k, k)
+    v = v.T / jnp.sqrt(d)[None, :]
 
     inv_scale = (1. / jnp.sqrt(n_subset))
     col_ixs = jax.random.choice(key5, m, shape=(n_subset,))  # (n_subset,)

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -567,7 +567,7 @@ class PointCloud(geometry.Geometry):
       (x, y, *children), aux_data = self.tree_flatten()
       x = x * jnp.sqrt(scale)
       y = y * jnp.sqrt(scale)
-      return PointCloud.tree_unflatten(aux_data, [x, y] + children)
+      return type(self).tree_unflatten(aux_data, [x, y] + children)
     return super().to_LRCGeometry(**kwargs)
 
   def _sqeucl_to_lr(self, scale: float = 1.0) -> low_rank.LRCGeometry:

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -85,6 +85,22 @@ class TestQuadraticProblem:
         assert not lr_prob._should_convert_to_low_rank
         assert lr_prob.to_low_rank() is lr_prob
 
+  def test_implicit_conversion_mixed_input(self, rng: jnp.ndarray):
+    n, m, d1, d2 = 200, 300, 20, 25
+    k1, k2 = jax.random.split(rng, 2)
+    x = jax.random.normal(k1, (n, d1))
+    y = jax.random.normal(k2, (m, d2))
+
+    geom_xx = pointcloud.PointCloud(x)
+    geom_yy = pointcloud.PointCloud(y).to_LRCGeometry()
+
+    prob = quad_problems.QuadraticProblem(geom_xx, geom_yy, ranks=-1)
+    lr_prob = prob.to_low_rank()
+
+    assert prob._should_convert_to_low_rank
+    assert lr_prob.is_low_rank
+    assert prob.geom_yy is lr_prob.geom_yy
+
 
 class TestGromovWasserstein:
 

--- a/tests/core/gromov_wasserstein_test.py
+++ b/tests/core/gromov_wasserstein_test.py
@@ -82,7 +82,7 @@ class TestQuadraticProblem:
         assert not lr_prob.is_low_rank
       else:
         assert lr_prob.is_low_rank
-        assert not lr_prob._should_convert_to_low_rank
+        assert lr_prob._is_low_rank_convertible
         assert lr_prob.to_low_rank() is lr_prob
 
   def test_implicit_conversion_mixed_input(self, rng: jnp.ndarray):
@@ -97,7 +97,7 @@ class TestQuadraticProblem:
     prob = quad_problems.QuadraticProblem(geom_xx, geom_yy, ranks=-1)
     lr_prob = prob.to_low_rank()
 
-    assert prob._should_convert_to_low_rank
+    assert prob._is_low_rank_convertible
     assert lr_prob.is_low_rank
     assert prob.geom_yy is lr_prob.geom_yy
 


### PR DESCRIPTION
In this PR:
- allow for passing different ranks/tolerances for geometries in GW when converting them to LR
- quadratic solver no longer modifies the problem in-place
- add `QuadraticProblem.to_low_rank(seed: int = 0)` method (similar could be done for `LinearProblem in the future`)

closes #112 