### PR TITLE
Fix `fused_penalty` and `scale_cost` in LRGW

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        flags: unittests-${{ matrix.test_mark }}
+        flags:
         env_vars: OS,PYTHON
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true

--- a/ott/core/gromov_wasserstein.py
+++ b/ott/core/gromov_wasserstein.py
@@ -251,6 +251,9 @@ class GromovWasserstein(was_solver.WassersteinSolver):
       init: Initial linearization of the quadratic problem.
       key: Random key for low-rank initializers. Only used when
       :attr:`warm_start` is `False`.
+
+    Returns:
+      The initial Gromov-Wasserstein state.
     """
     linear_state = self.linear_ot_solver(init)
     num_iter = self.max_iterations

--- a/ott/core/initializers_lr.py
+++ b/ott/core/initializers_lr.py
@@ -461,8 +461,8 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
   Args:
     rank: Rank of the factorization.
     gamma: The (inverse of) gradient step size used by mirror descent.
-    min_iterations: Minimum number of iterations.
-    max_iterations: Maximum number of iterations.
+    min_iterations: Minimum number of k-means iterations.
+    max_iterations: Maximum number of k-means iterations.
     inner_iterations: Number of iterations used by the algorithm before
       re-evaluating progress.
     threshold: Convergence threshold.

--- a/ott/core/initializers_lr.py
+++ b/ott/core/initializers_lr.py
@@ -342,8 +342,8 @@ class KMeansInitializer(LRInitializer):
 
   Args:
     rank: Rank of the factorization.
-    min_iterations: Minimum number of iterations.
-    max_iterations: Maximum number of iterations.
+    min_iterations: Minimum number of k-means iterations.
+    max_iterations: Maximum number of k-means iterations.
     sinkhorn_kwargs: Keyword arguments for :class:`~ott.core.sinkhorn.Sinkhorn`.
     kwargs: Keyword arguments for :func:`~ott.tools.k_means.k_means`.
   """
@@ -461,8 +461,8 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
   Args:
     rank: Rank of the factorization.
     gamma: The (inverse of) gradient step size used by mirror descent.
-    min_iterations: Minimum number of k-means iterations.
-    max_iterations: Maximum number of k-means iterations.
+    min_iterations: Minimum number of iterations.
+    max_iterations: Maximum number of iterations.
     inner_iterations: Number of iterations used by the algorithm before
       re-evaluating progress.
     threshold: Convergence threshold.
@@ -620,11 +620,9 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
     assert geom.shape[0] == geom.shape[
         1], f"Expected the shape to be square, found `{geom.shape}`."
 
-    min_iter = self._kwargs["min_iterations"]
-    max_iter = self._kwargs["max_iterations"]
     inner_iterations = self._kwargs["inner_iterations"]
-    outer_iterations = np.ceil(max_iter / inner_iterations).astype(int)
-    force_scan = min_iter == max_iter
+    outer_iterations = np.ceil(self._max_iter / inner_iterations).astype(int)
+    force_scan = self._min_iter == self._max_iter
     fixpoint_fn = (
         fixed_point_loop.fixpoint_iter
         if force_scan else fixed_point_loop.fixpoint_iter_backprop
@@ -642,8 +640,8 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
     return fixpoint_fn(
         cond_fn,
         body_fn,
-        min_iterations=min_iter,
-        max_iterations=max_iter,
+        min_iterations=self._min_iter,
+        max_iterations=self._max_iter,
         inner_iterations=inner_iterations,
         constants=consts,
         state=init_fn(),

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -307,10 +307,9 @@ class QuadraticProblem:
     tmp1 = apply_cost(self.geom_xx, q, axis=1, fn=h1)
     tmp2 = apply_cost(self.geom_yy, r, axis=1, fn=h2)
     if self.is_low_rank:
-      geom = low_rank.LRCGeometry(cost_1=tmp1, cost_2=-tmp2)
-      geom = low_rank.add_lrc_geom(geom, marginal_cost)
+      geom = low_rank.LRCGeometry(cost_1=tmp1, cost_2=-tmp2) + marginal_cost
       if self.is_fused:
-        geom = low_rank.add_lrc_geom(geom, self.geom_xy)
+        geom = geom + self.geom_xy
     else:
       cost_matrix = marginal_cost.cost_matrix - jnp.dot(tmp1, tmp2.T)
       cost_matrix += self.fused_penalty * self._fused_cost_matrix

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -445,8 +445,9 @@ class QuadraticProblem:
       if isinstance(
           geom_xy, pointcloud.PointCloud
       ) and geom_xy.is_squared_euclidean:
-        geom_xy = geom_xy.to_LRCGeometry(self.fused_penalty)
+        geom_xy = geom_xy.to_LRCGeometry(scale=self.fused_penalty)
       else:
+        # TODO(michalk8): pass scale
         geom_xy = geom_xy.to_LRCGeometry(rank=r3, tol=t3, seed=s3)
 
     return type(self).tree_unflatten(

--- a/ott/core/quad_problems.py
+++ b/ott/core/quad_problems.py
@@ -447,8 +447,9 @@ class QuadraticProblem:
       ) and geom_xy.is_squared_euclidean:
         geom_xy = geom_xy.to_LRCGeometry(scale=self.fused_penalty)
       else:
-        # TODO(michalk8): pass scale
-        geom_xy = geom_xy.to_LRCGeometry(rank=r3, tol=t3, seed=s3)
+        geom_xy = geom_xy.to_LRCGeometry(
+            rank=r3, tol=t3, seed=s3, scale=self.fused_penalty
+        )
 
     return type(self).tree_unflatten(
         aux_data, [geom_xx, geom_yy, geom_xy] + children

--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -618,7 +618,8 @@ class Geometry:
       self,
       rank: int,
       tol: float = 1e-2,
-      seed: int = 0
+      seed: int = 0,
+      scale: float = 1.
   ) -> 'low_rank.LRCGeometry':
     r"""Factorize the cost matrix in sublinear time :cite:`indyk:19`.
 
@@ -634,9 +635,11 @@ class Geometry:
       tol: Tolerance of the error. The total number of sampled points is
         :math:`min(n, m,\frac{rank}{tol})`.
       seed: Random seed.
+      scale: Value used to rescale the factors of the low-rank geometry.
+        Useful when this geometry is used in the linear term of fused GW.
 
     Returns:
-      Low-rank geometry.
+      The low-rank geometry.
     """
     from ott.geometry import low_rank
 
@@ -696,6 +699,7 @@ class Geometry:
         relative_epsilon=self._relative_epsilon,
         scale=self._scale_epsilon,
         scale_cost=self._scale_cost,
+        scale_factor=scale,
         **self._kwargs
     )
 

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -290,6 +290,14 @@ class LRCGeometry(geometry.Geometry):
         aux_data, [c1, c2, src_mask, tgt_mask] + children
     )
 
+  def __add__(self, other: 'LRCGeometry') -> 'LRCGeometry':
+    assert isinstance(other, LRCGeometry), type(other)
+    return type(self)(
+        cost_1=jnp.concatenate((self.cost_1, other.cost_1), axis=1),
+        cost_2=jnp.concatenate((self.cost_2, other.cost_2), axis=1),
+        **self._kwargs
+    )
+
   def tree_flatten(self):
     return (
         self._cost_1, self._cost_2, self._src_mask, self._tgt_mask, self._kwargs
@@ -306,12 +314,3 @@ class LRCGeometry(geometry.Geometry):
     return cls(
         c1, c2, src_mask=src_mask, tgt_mask=tgt_mask, **kwargs, **aux_data
     )
-
-
-def add_lrc_geom(geom1: LRCGeometry, geom2: LRCGeometry) -> LRCGeometry:
-  """Add geometry in geom1 to that in geom2, keeping other geom1 params."""
-  return LRCGeometry(
-      cost_1=jnp.concatenate((geom1.cost_1, geom2.cost_1), axis=1),
-      cost_2=jnp.concatenate((geom1.cost_2, geom2.cost_2), axis=1),
-      **geom1._kwargs
-  )

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -47,7 +47,8 @@ class LRCGeometry(geometry.Geometry):
       self,
       cost_1: jnp.ndarray,
       cost_2: jnp.ndarray,
-      bias: float = 0.0,
+      bias: float = 0.,
+      scale_factor: float = 1.,
       scale_cost: Union[bool, int, float, Literal['mean', 'max_bound',
                                                   'max_cost']] = 1.0,
       batch_size: Optional[int] = None,
@@ -57,6 +58,7 @@ class LRCGeometry(geometry.Geometry):
     self._cost_1 = cost_1
     self._cost_2 = cost_2
     self._bias = bias
+    self._scale_factor = scale_factor
     self._kwargs = kwargs
 
     super().__init__(**kwargs)
@@ -66,12 +68,14 @@ class LRCGeometry(geometry.Geometry):
   @property
   def cost_1(self) -> jnp.ndarray:
     """First factor of the :attr:`cost_matrix`."""
-    return self._cost_1 * jnp.sqrt(self.inv_scale_cost)
+    scale_factor = jnp.sqrt(self._scale_factor * self.inv_scale_cost)
+    return scale_factor * self._cost_1
 
   @property
   def cost_2(self) -> jnp.ndarray:
     """Second factor of the :attr:`cost_matrix`."""
-    return self._cost_2 * jnp.sqrt(self.inv_scale_cost)
+    scale_factor = jnp.sqrt(self._scale_factor * self.inv_scale_cost)
+    return scale_factor * self._cost_2
 
   @property
   def bias(self) -> float:
@@ -290,6 +294,7 @@ class LRCGeometry(geometry.Geometry):
         self._cost_1, self._cost_2, self._src_mask, self._tgt_mask, self._kwargs
     ), {
         'bias': self._bias,
+        'scale_factor': self._scale_factor,
         'scale_cost': self._scale_cost,
         'batch_size': self.batch_size
     }

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -25,7 +25,14 @@ from ott.geometry import geometry
 
 @jax.tree_util.register_pytree_node_class
 class LRCGeometry(geometry.Geometry):
-  """Low-rank Cost Geometry defined by two factors.
+  """Geometry whose cost is defined by product of two low-rank matrices.
+
+  Implements geometries that are defined as low rank products, i.e. for which
+  there exists two matrices :math:`A` and :math:`B` of :math:`r` columns such
+  that the cost of the geometry equals :math:`AB^T`. Apart from being faster to
+  apply to a vector, these geometries are characterized by the fact that adding
+  two such geometries should be carried out by the concatenating factors, i.e.
+  if :math:`C = AB^T` and :math:`D = EF^T` then :math:`C + D = [A,E][B,F]^T`
 
   Args:
     cost_1: jnp.ndarray<float>[num_a, r]

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -31,7 +31,7 @@ class LRCGeometry(geometry.Geometry):
   there exists two matrices :math:`A` and :math:`B` of :math:`r` columns such
   that the cost of the geometry equals :math:`AB^T`. Apart from being faster to
   apply to a vector, these geometries are characterized by the fact that adding
-  two such geometries should be carried out by the concatenating factors, i.e.
+  two such geometries should be carried out by concatenating factors, i.e.
   if :math:`C = AB^T` and :math:`D = EF^T` then :math:`C + D = [A,E][B,F]^T`
 
   Args:

--- a/ott/geometry/low_rank.py
+++ b/ott/geometry/low_rank.py
@@ -31,6 +31,7 @@ class LRCGeometry(geometry.Geometry):
     cost_1: jnp.ndarray<float>[num_a, r]
     cost_2: jnp.ndarray<float>[num_b, r]
     bias: constant added to entire cost matrix.
+    scale: Value used to rescale the factors of the low-rank geometry.
     scale_cost: option to rescale the cost matrix. Implemented scalings are
       'max_bound', 'mean' and 'max_cost'. Alternatively, a float
       factor can be given to rescale the cost such that

--- a/ott/geometry/pointcloud.py
+++ b/ott/geometry/pointcloud.py
@@ -593,10 +593,9 @@ class PointCloud(geometry.Geometry):
       (n, m), d = self.shape, self.x.shape[1]
       if n * m > (n + m) * d:  # here apply_cost using LRCGeometry preferable.
         return self._sqeucl_to_lr(scale)
-      (x, y, *children), aux_data = self.tree_flatten()
-      x = x * jnp.sqrt(scale)
-      y = y * jnp.sqrt(scale)
-      return type(self).tree_unflatten(aux_data, [x, y] + children)
+      # TODO(michalk8): explain why we don't update scale factor
+      return self
+    # TODO(michalk8): pass scale factor
     return super().to_LRCGeometry(**kwargs)
 
   def _sqeucl_to_lr(self, scale: float = 1.0) -> low_rank.LRCGeometry:
@@ -613,12 +612,10 @@ class PointCloud(geometry.Geometry):
                                   keepdims=True), jnp.sqrt(2) * self.y
     ),
                              axis=1)
-    cost_1 *= jnp.sqrt(scale)
-    cost_2 *= jnp.sqrt(scale)
-
     return low_rank.LRCGeometry(
         cost_1=cost_1,
         cost_2=cost_2,
+        scale_factor=scale,
         epsilon=self._epsilon_init,
         relative_epsilon=self._relative_epsilon,
         scale=self._scale_epsilon,

--- a/tests/geometry/geometry_lr_test.py
+++ b/tests/geometry/geometry_lr_test.py
@@ -109,7 +109,7 @@ class TestLRGeometry:
 
     geom_lr_c = low_rank.LRCGeometry(c1, c2)
     geom_lr_d = low_rank.LRCGeometry(d1, d2)
-    geom_lr = low_rank.add_lrc_geom(geom_lr_c, geom_lr_d)
+    geom_lr = geom_lr_c + geom_lr_d
 
     for dim, axis in ((m, 1), (n, 0)):
       mat = jax.random.normal(keys[1], (dim, 2))
@@ -124,6 +124,34 @@ class TestLRGeometry:
           geom_lr.apply_cost(vec, axis=axis),
           rtol=1e-4
       )
+
+  @pytest.mark.parametrize(
+      "scale,scale_cost,epsilon", [(0.1, "mean", None), (0.9, "max_cost", 1e-2)]
+  )
+  def test_add_lr_geoms_scale_factor(
+      self, rng: jnp.ndarray, scale: float, scale_cost: str,
+      epsilon: Optional[float]
+  ):
+    n, d = 71, 2
+    key1, key2 = jax.random.split(rng, 2)
+
+    geom1 = pointcloud.PointCloud(
+        jax.random.normal(key1, (n, d)) + 10.,
+        epsilon=epsilon,
+        scale_cost=scale_cost
+    )
+    geom2 = pointcloud.PointCloud(
+        jax.random.normal(key2, (n, d)) + 20.,
+        epsilon=epsilon,
+        scale_cost=scale_cost
+    )
+    geom_lr = geom1.to_LRCGeometry(scale=1 - scale) + \
+        geom2.to_LRCGeometry(scale=scale)
+
+    expected = (1 - scale) * geom1.cost_matrix + scale * geom2.cost_matrix
+    actual = geom_lr.cost_matrix
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-3, atol=1e-3)
 
   @pytest.mark.parametrize("axis", [0, 1])
   @pytest.mark.parametrize("fn", [lambda x: x + 10, lambda x: x * 2])

--- a/tests/geometry/geometry_lr_test.py
+++ b/tests/geometry/geometry_lr_test.py
@@ -190,9 +190,9 @@ class TestLRGeometry:
     if n * m > (n + m) * rank:
       assert isinstance(geom_lr, low_rank.LRCGeometry)
     else:
-      assert isinstance(geom_lr, pointcloud.PointCloud)
-      np.testing.assert_allclose(geom_lr.x, jnp.sqrt(scale) * geom_pc.x)
-      np.testing.assert_allclose(geom_lr.y, jnp.sqrt(scale) * geom_pc.y)
+      # TODO(michalk8): scale is currently ignored by design,
+      # will be changed in the future
+      assert geom_lr is geom_pc
 
 
 class TestCostMatrixFactorization:


### PR DESCRIPTION
In case of low-rank geometries, the inverse scaling of the cost was applied after taking into account `fused_penalty`, effectively negating the effect.