### PR TITLE
Feature/depracate functional api

### DIFF
--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -19,11 +19,12 @@ import jax.numpy as jnp
 import numpy as np
 from typing_extensions import Literal
 
+from ott import utils
 from ott.geometry import geometry
 from ott.initializers.linear import initializers as init_lib
 from ott.math import fixed_point_loop
 from ott.math import unbalanced_functions as uf
-from ott.math import utils
+from ott.math import utils as mu
 from ott.problems.linear import linear_problem, potentials
 from ott.solvers.linear import acceleration
 from ott.solvers.linear import implicit_differentiation as implicit_lib
@@ -107,8 +108,8 @@ class SinkhornState(NamedTuple):
     tau = rho_a * rho_b / (rho_a + rho_b)
 
     shift = tau * (
-        utils.logsumexp(-f / rho_a, b=ot_prob.a) -
-        utils.logsumexp(-g / rho_b, b=ot_prob.b)
+        mu.logsumexp(-f / rho_a, b=ot_prob.a) -
+        mu.logsumexp(-g / rho_b, b=ot_prob.b)
     )
     return f + shift, g - shift
 
@@ -551,7 +552,7 @@ class Sinkhorn:
         potential: jnp.ndarray, marginal: jnp.ndarray, tau: float
     ) -> float:
       rho = uf.rho(ot_prob.epsilon, tau)
-      return -rho * utils.logsumexp(-potential / rho, b=marginal)
+      return -rho * mu.logsumexp(-potential / rho, b=marginal)
 
     # only for an unbalanced problems with `tau_{a,b} < 1`
     recenter = (
@@ -921,6 +922,7 @@ def make(
   )
 
 
+@utils.deprecate(version="0.3.2", alt="Use the `Sinkhorn` class instead.")
 def sinkhorn(
     geom: geometry.Geometry,
     a: Optional[jnp.ndarray] = None,

--- a/src/ott/solvers/quadratic/gromov_wasserstein.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein.py
@@ -18,6 +18,7 @@ import jax
 import jax.numpy as jnp
 from typing_extensions import Literal
 
+from ott import utils
 from ott.geometry import epsilon_scheduler, geometry, low_rank, pointcloud
 from ott.initializers.linear import initializers_lr
 from ott.initializers.quadratic import initializers as quad_initializers
@@ -452,6 +453,9 @@ def make(
   )
 
 
+@utils.deprecate(
+    version="0.3.2", alt="Use the `GromovWasserstein` class instead."
+)
 def gromov_wasserstein(
     geom_xx: geometry.Geometry,
     geom_yy: geometry.Geometry,

--- a/src/ott/tools/transport.py
+++ b/src/ott/tools/transport.py
@@ -32,6 +32,7 @@ import jax.numpy as jnp
 import numpy as np
 from typing_extensions import Literal
 
+from ott import utils
 from ott.geometry import geometry, pointcloud
 from ott.problems.linear import linear_problem
 from ott.problems.quadratic import quadratic_problem
@@ -79,6 +80,7 @@ class Transport(NamedTuple):
     return self.linear_output.marginal(axis)
 
 
+@utils.deprecate(version="0.3.2")
 def solve(
     *args: Any,
     a: Optional[jnp.ndarray] = None,

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """pytree_nodes Dataclasses."""
-
 import dataclasses
+import functools
+import warnings
+from typing import Any, Callable, Optional
 
 import jax
 
-__all__ = ["register_pytree_node"]
+__all__ = ["register_pytree_node", "deprecate"]
 
 
 def register_pytree_node(cls: type) -> type:
@@ -27,3 +29,27 @@ def register_pytree_node(cls: type) -> type:
   unflatten = lambda d, children: cls(**d.unflatten(children))
   jax.tree_util.register_pytree_node(cls, flatten, unflatten)
   return cls
+
+
+def deprecate(
+    *,
+    version: Optional[str] = None,
+    alt_msg: Optional[str] = None,
+    func: Optional[Callable[[Any], Any]] = None
+) -> Callable[[Any], Any]:
+
+  def wrapper(*args: Any, **kwargs: Any) -> Any:
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+    return func(*args, **kwargs)
+
+  if func is None:
+    return lambda fn: deprecate(version=version, alt_msg=alt_msg, func=fn)
+
+  if version is None:
+    msg = f"`{func.__name__}` will be removed the next version."
+  else:
+    msg = f"`{func.__name__}` will be removed in version `{version}`."
+  if alt_msg:
+    msg += " " + alt_msg
+
+  return functools.wraps(func)(wrapper)

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -34,7 +34,7 @@ def register_pytree_node(cls: type) -> type:
 def deprecate(
     *,
     version: Optional[str] = None,
-    alt_msg: Optional[str] = None,
+    alt: Optional[str] = None,
     func: Optional[Callable[[Any], Any]] = None
 ) -> Callable[[Any], Any]:
 
@@ -43,13 +43,11 @@ def deprecate(
     return func(*args, **kwargs)
 
   if func is None:
-    return lambda fn: deprecate(version=version, alt_msg=alt_msg, func=fn)
+    return lambda fn: deprecate(version=version, alt=alt, func=fn)
 
-  if version is None:
-    msg = f"`{func.__name__}` will be removed the next version."
-  else:
-    msg = f"`{func.__name__}` will be removed in version `{version}`."
-  if alt_msg:
-    msg += " " + alt_msg
+  msg = f"`{func.__name__}` will be removed in the "
+  msg += ("next" if version is None else f"`ott-jax=={version}`") + " release."
+  if alt:
+    msg += " " + alt
 
   return functools.wraps(func)(wrapper)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+import pytest
+
+from ott import utils
+
+
+@pytest.mark.parametrize(
+    "version,msg", [(None, "foo, bar, baz"), ("quux", None)]
+)
+def test_deprecation_warning(version: Optional[str], msg: Optional[str]):
+
+  @utils.deprecate(version=version, alt=msg)
+  def func() -> int:
+    return 42
+
+  expected_msg = rf"`{func.__name__}`"
+  if version is None:
+    expected_msg += r".*next release\."
+  else:
+    expected_msg += rf".*`ott-jax=={version}` release\."
+  if msg is not None:
+    expected_msg += f" {msg}"
+
+  with pytest.warns(DeprecationWarning, match=expected_msg):
+    res = func()
+  assert res == 42


### PR DESCRIPTION
Add `DeprecationWarning` for:

- `sinkhorn.sinkhorn`
- `gromov_wasserstein.gromow_wasserstein`
- `transport.solve`

functions in favor of the other interface.
closes #170 