### PR TITLE
Fixes numerical errors in Bures barycenter, and `sqrtm`, due to low default precision.

### DIFF
--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -306,7 +306,7 @@ class Bures(CostFn):
       covs: jnp.ndarray,
       weights: jnp.ndarray,
       tolerance: float = 1e-4,
-      **kwargs
+      **kwargs: Any
   ) -> jnp.ndarray:
     """Iterate fix-point updates to compute barycenter of Gaussians.
 

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -15,7 +15,7 @@
 import abc
 import functools
 import math
-from typing import Any, Callable, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -15,7 +15,7 @@
 import abc
 import functools
 import math
-from typing import Any, Callable, Optional, Tuple, Union, Mapping
+from typing import Any, Callable, Mapping, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -309,26 +309,26 @@ class Bures(CostFn):
       kwargs_sqrtm: Optional[Mapping[str, Any]] = None
   ) -> jnp.ndarray:
     """Iterate fix-point updates to compute barycenter of Gaussians.
-    
+
     Args:
       covs: [batch, d^2] covariance matrices
       weights: simplicial weights (nonnegative, sum to 1)
       tolerance: tolerance of the overall fixed-point procedure
-      kwargs_sqrtm: parameters passed on to the sqrtm (Newton-Schulz) 
+      kwargs_sqrtm: parameters passed on to the sqrtm (Newton-Schulz)
         algorithm to compute matrix square roots.
-    
+
     Returns:
       a covariance matrix, the weighted Bures average of the covs matrices.
     """
     kwargs_sqrtm = {} if kwargs_sqrtm is None else kwargs_sqrtm
+
     @functools.partial(jax.vmap, in_axes=[None, 0, 0])
     def scale_covariances(
         cov_sqrt: jnp.ndarray, cov: jnp.ndarray, weight: jnp.ndarray
     ) -> jnp.ndarray:
       """Rescale covariance in barycenter step."""
-      return weight * matrix_square_root.sqrtm_only(
-          (cov_sqrt @ cov) @ cov_sqrt, **kwargs_sqrtm
-      )
+      return weight * matrix_square_root.sqrtm_only((cov_sqrt @ cov) @ cov_sqrt,
+                                                    **kwargs_sqrtm)
 
     def cond_fn(iteration: int, constants: Tuple[Any, ...], state) -> bool:
       del iteration, constants
@@ -366,10 +366,8 @@ class Bures(CostFn):
     return cov
 
   def barycenter(
-    self,
-    weights: jnp.ndarray,
-    xs: jnp.ndarray,
-    **kwargs) -> jnp.ndarray:
+      self, weights: jnp.ndarray, xs: jnp.ndarray, **kwargs
+  ) -> jnp.ndarray:
     """Compute the Bures barycenter of weighted Gaussian distributions.
 
     Implements the fixed point approach proposed in :cite:`alvarez-esteban:16`
@@ -391,7 +389,8 @@ class Bures(CostFn):
     mus, covs = x_to_means_and_covs(xs, self._dimension)
     mu_bary = jnp.sum(weights[:, None] * mus, axis=0)
     cov_bary = self.covariance_fixpoint_iter(
-      covs=covs, weights=weights, **kwargs)
+        covs=covs, weights=weights, **kwargs
+    )
     barycenter = mean_and_cov_to_x(mu_bary, cov_bary, self._dimension)
     return barycenter
 

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -365,7 +365,7 @@ class Bures(CostFn):
     return cov
 
   def barycenter(
-      self, weights: jnp.ndarray, xs: jnp.ndarray, **kwargs
+      self, weights: jnp.ndarray, xs: jnp.ndarray, **kwargs: Any
   ) -> jnp.ndarray:
     """Compute the Bures barycenter of weighted Gaussian distributions.
 

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -353,7 +353,7 @@ class Bures(CostFn):
       diff = jnp.inf
       return cov_init, diff
 
-    #TODO(marcocuturi): ideally the integer parameters below should be passed
+    # TODO(marcocuturi): ideally the integer parameters below should be passed
     # by user, if one wants more fine grained control. This could clash with the
     # parameters passed on to :func:`ott.math.matrix_square_root.sqrtm` by the
     # barycenter call. At the moment, only `tolerance` can be used to control

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -353,10 +353,15 @@ class Bures(CostFn):
       diff = jnp.inf
       return cov_init, diff
 
+    #TODO(marcocuturi): ideally the integer parameters below should be passed
+    # by user, if one wants more fine grained control. This could clash with the
+    # parameters passed on to :func:`ott.math.matrix_square_root.sqrtm` by the
+    # barycenter call. At the moment, only `tolerance` can be used to control
+    # computational effort.
     cov, _ = fixed_point_loop.fixpoint_iter(
         cond_fn=cond_fn,
         body_fn=body_fn,
-        min_iterations=10,
+        min_iterations=1,
         max_iterations=500,
         inner_iterations=1,
         constants=(),
@@ -378,8 +383,10 @@ class Bures(CostFn):
       xs: The points to be used in the computation of the barycenter, where
         each point is described by a concatenation of the mean and the
         covariance (raveled).
-      kwargs: Passed on to :meth:`covariance_fixpoint_iter`, by extension to
-        `sqrtm`.
+      kwargs: Passed on to :meth:`covariance_fixpoint_iter`, and by extension to
+        :func:`ott.math.matrix_square_root.sqrtm`. Note that `tolerance` is used
+        for the fixed-point iteration of the barycenter, whereas `threshold` will apply to the fixed
+        point iteration of Newton-Schulz iterations.
 
     Returns:
       A concatenation of the mean and the raveled covariance of the barycenter.

--- a/src/ott/math/matrix_square_root.py
+++ b/src/ott/math/matrix_square_root.py
@@ -266,6 +266,8 @@ def sqrtm_only_bwd(
     max_iterations: int, regularization: float, sqrt_x: jnp.ndarray,
     cotangent: jnp.ndarray
 ) -> Tuple[jnp.ndarray]:
+  del threshold, min_iterations, inner_iterations
+  del max_iterations, regularization
   vjp = jnp.swapaxes(
       solve_sylvester_bartels_stewart(
           a=sqrt_x, b=-sqrt_x, c=jnp.swapaxes(cotangent, axis1=-2, axis2=-1)

--- a/src/ott/math/matrix_square_root.py
+++ b/src/ott/math/matrix_square_root.py
@@ -242,34 +242,30 @@ def sqrtm_only(
     min_iterations: int = 0,
     inner_iterations: int = 10,
     max_iterations: int = 1000,
-    regularization: float = 1e-6) -> jnp.ndarray:
-  return sqrtm(x, threshold, min_iterations, inner_iterations,
-    max_iterations, regularization)[0]
+    regularization: float = 1e-6
+) -> jnp.ndarray:
+  return sqrtm(
+      x, threshold, min_iterations, inner_iterations, max_iterations,
+      regularization
+  )[0]
 
 
 def sqrtm_only_fwd(
-    x: jnp.ndarray,
-    threshold: float,
-    min_iterations: int,
-    inner_iterations: int,
-    max_iterations: int,
-    regularization: float
-    ) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    x: jnp.ndarray, threshold: float, min_iterations: int,
+    inner_iterations: int, max_iterations: int, regularization: float
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
   sqrt_x = sqrtm(
-    x, threshold, min_iterations, inner_iterations,
-    max_iterations, regularization)[0]
+      x, threshold, min_iterations, inner_iterations, max_iterations,
+      regularization
+  )[0]
   return sqrt_x, sqrt_x
 
 
 def sqrtm_only_bwd(
-    threshold: float,
-    min_iterations: int,
-    inner_iterations: int,
-    max_iterations: int,
-    regularization: float,
-    sqrt_x: jnp.ndarray,
+    threshold: float, min_iterations: int, inner_iterations: int,
+    max_iterations: int, regularization: float, sqrt_x: jnp.ndarray,
     cotangent: jnp.ndarray
-    ) -> Tuple[jnp.ndarray]:
+) -> Tuple[jnp.ndarray]:
   vjp = jnp.swapaxes(
       solve_sylvester_bartels_stewart(
           a=sqrt_x, b=-sqrt_x, c=jnp.swapaxes(cotangent, axis1=-2, axis2=-1)
@@ -290,9 +286,12 @@ def inv_sqrtm_only(
     min_iterations: int = 0,
     inner_iterations: int = 10,
     max_iterations: int = 1000,
-    regularization: float = 1e-6) -> jnp.ndarray:
-  return sqrtm(x, threshold, min_iterations, inner_iterations,
-    max_iterations, regularization)[1]
+    regularization: float = 1e-6
+) -> jnp.ndarray:
+  return sqrtm(
+      x, threshold, min_iterations, inner_iterations, max_iterations,
+      regularization
+  )[1]
 
 
 def inv_sqrtm_only_fwd(
@@ -302,20 +301,19 @@ def inv_sqrtm_only_fwd(
     inner_iterations: int,
     max_iterations: int,
     regularization: float,
-  ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-  inv_sqrt_x = sqrtm(x,threshold, min_iterations, inner_iterations,
-    max_iterations, regularization)[1]
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  inv_sqrt_x = sqrtm(
+      x, threshold, min_iterations, inner_iterations, max_iterations,
+      regularization
+  )[1]
   return inv_sqrt_x, inv_sqrt_x
 
 
 def inv_sqrtm_only_bwd(
-    threshold: float,
-    min_iterations: int,
-    inner_iterations: int,
-    max_iterations: int,
-    regularization: float,
-    residual: jnp.ndarray,
-    cotangent: jnp.ndarray) -> Tuple[jnp.ndarray]:
+    threshold: float, min_iterations: int, inner_iterations: int,
+    max_iterations: int, regularization: float, residual: jnp.ndarray,
+    cotangent: jnp.ndarray
+) -> Tuple[jnp.ndarray]:
   inv_sqrt_x = residual
   inv_x = jnp.matmul(inv_sqrt_x, inv_sqrt_x)
   vjp = jnp.swapaxes(

--- a/tests/geometry/costs_test.py
+++ b/tests/geometry/costs_test.py
@@ -65,3 +65,25 @@ class TestCostFn:
         np.testing.assert_allclose(
             cosine_fn.pairwise(x[i], y[j]), all_pairs[i, j]
         )
+
+  @pytest.mark.fast
+  class TestBuresBarycenter:
+    def test_buresb(self, rng: jnp.ndarray):
+      d=5
+      r = jnp.array([0.3206, 0.8825, 0.1113, 0.00052, 0.9454])
+      Sigma1 = r * jnp.eye(d)
+      s = jnp.array([0.3075, 0.8545, 0.1110, 0.0054, 0.9206])
+      Sigma2 = s * jnp.eye(d)
+      # initializing Bures cost function
+      weights = jnp.array([.3, .7])
+      bures = costs.Bures(d)
+      # stacking parameter values
+      xs = jnp.vstack((
+        costs.mean_and_cov_to_x(jnp.zeros((d,)), Sigma1, d),
+        costs.mean_and_cov_to_x(jnp.zeros((d,)), Sigma2, d)))
+
+      output = bures.barycenter(weights, xs, tolerance=1e-4, threshold=1e-6)
+      _, sigma = costs.x_to_means_and_covs(output, 5)
+      ground_truth= (weights[0]*jnp.sqrt(r) + weights[1]*jnp.sqrt(s))**2
+      np.testing.assert_allclose(
+        ground_truth, jnp.diag(sigma), rtol=1e-5, atol=1e-5)

--- a/tests/geometry/costs_test.py
+++ b/tests/geometry/costs_test.py
@@ -68,8 +68,9 @@ class TestCostFn:
 
   @pytest.mark.fast
   class TestBuresBarycenter:
+
     def test_buresb(self, rng: jnp.ndarray):
-      d=5
+      d = 5
       r = jnp.array([0.3206, 0.8825, 0.1113, 0.00052, 0.9454])
       Sigma1 = r * jnp.eye(d)
       s = jnp.array([0.3075, 0.8545, 0.1110, 0.0054, 0.9206])
@@ -79,11 +80,13 @@ class TestCostFn:
       bures = costs.Bures(d)
       # stacking parameter values
       xs = jnp.vstack((
-        costs.mean_and_cov_to_x(jnp.zeros((d,)), Sigma1, d),
-        costs.mean_and_cov_to_x(jnp.zeros((d,)), Sigma2, d)))
+          costs.mean_and_cov_to_x(jnp.zeros((d,)), Sigma1, d),
+          costs.mean_and_cov_to_x(jnp.zeros((d,)), Sigma2, d)
+      ))
 
       output = bures.barycenter(weights, xs, tolerance=1e-4, threshold=1e-6)
       _, sigma = costs.x_to_means_and_covs(output, 5)
-      ground_truth= (weights[0]*jnp.sqrt(r) + weights[1]*jnp.sqrt(s))**2
+      ground_truth = (weights[0] * jnp.sqrt(r) + weights[1] * jnp.sqrt(s)) ** 2
       np.testing.assert_allclose(
-        ground_truth, jnp.diag(sigma), rtol=1e-5, atol=1e-5)
+          ground_truth, jnp.diag(sigma), rtol=1e-5, atol=1e-5
+      )

--- a/tests/math/matrix_square_root_test.py
+++ b/tests/math/matrix_square_root_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for matrix square roots."""
-from typing import Callable
+from typing import Callable, Any
 
 import jax
 import jax.numpy as jnp
@@ -38,7 +38,8 @@ def _get_random_spd_matrix(dim: int, key: jnp.ndarray):
 
 
 def _get_test_fn(
-    fn: Callable[[jnp.ndarray], jnp.ndarray], dim: int, key: jnp.ndarray
+    fn: Callable[[jnp.ndarray], jnp.ndarray], dim: int, key: jnp.ndarray,
+    **kwargs: Any
 ) -> Callable[[jnp.ndarray], jnp.ndarray]:
   # We want to test gradients of a function fn that maps positive definite
   # matrices to positive definite matrices by comparing them to finite
@@ -54,11 +55,11 @@ def _get_test_fn(
   unit = jax.random.normal(key=subkey3, shape=(dim, dim))
   unit /= jnp.sqrt(jnp.sum(unit ** 2.))
 
-  def _test_fn(x: jnp.ndarray) -> jnp.ndarray:
+  def _test_fn(x: jnp.ndarray, **kwargs: Any) -> jnp.ndarray:
     # m is the product of 2 symmetric, positive definite matrices
     # so it will be positive definite but not necessarily symmetric
     m = jnp.matmul(m0, m1 + x * dx)
-    return jnp.sum(fn(m) * unit)
+    return jnp.sum(fn(m, **kwargs) * unit)
 
   return _test_fn
 

--- a/tests/math/matrix_square_root_test.py
+++ b/tests/math/matrix_square_root_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for matrix square roots."""
-from typing import Callable, Any
+from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp

--- a/tests/math/matrix_square_root_test.py
+++ b/tests/math/matrix_square_root_test.py
@@ -189,7 +189,7 @@ class TestMatrixSquareRoot:
     key = self.rng
     for _ in range(n_tests):
       key, subkey = jax.random.split(key)
-      test_fn = _get_test_fn(fn, dim=dim, key=subkey)
+      test_fn = _get_test_fn(fn, dim=dim, key=subkey, threshold=1e-5)
       expected = (test_fn(epsilon) - test_fn(-epsilon)) / (2. * epsilon)
       actual = jax.grad(test_fn)(0.)
       np.testing.assert_allclose(actual, expected, atol=atol, rtol=rtol)

--- a/tests/tools/gaussian_mixture/gaussian_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_test.py
@@ -118,7 +118,7 @@ class TestGaussian:
     delta_mean = jnp.sum((loc1 - loc0) ** 2., axis=-1)
     delta_sigma = jnp.sum((jnp.sqrt(diag0) - jnp.sqrt(diag1)) ** 2.)
     expected = delta_mean + delta_sigma
-    np.testing.assert_allclose(expected, w2)
+    np.testing.assert_allclose(expected, w2, rtol=1e-6, atol=1e-6)
 
   def test_transport(self, rng: jnp.ndarray):
     diag0 = jnp.array([1.])


### PR DESCRIPTION
This allows user to pass on `kwargs` parameters to Bures barycenters, solving #199. 

This also lowers the default tolerance of `sqrtm`.

example in #199  that was failing now works, with
```
import ott
from ott.geometry.costs import Bures, mean_and_cov_to_x, x_to_means_and_covs
import jax.numpy as jnp
from jax.config import config
config.update("jax_enable_x64", True)
# first Gaussian 
mu1 = jnp.array([-0.8909, -0.3568, 0.2758, 0.0352, -0.1457])
r = jnp.array([0.3206, 0.8825, 0.1113, 0.0052, 0.9454])
Sigma1 = r * jnp.eye(5)
# second Gaussian 
mu2 = jnp.array([-0.8862, -0.3652, 0.2751, 0.0349, -0.1486])
s = jnp.array([0.3075, 0.8545, 0.1110, 0.0054, 0.9206])
Sigma2 = s * jnp.eye(5)

# initializing Bures instance 
weights = jnp.array([300./537., 237./537.])
bures = Bures(5)

# stacking parameter values
xs = jnp.vstack(
    (mean_and_cov_to_x(mu1, Sigma1, 5), 
    mean_and_cov_to_x(mu2, Sigma2, 5))
)

# print output

output = bures.barycenter(weights, xs, tolerance=1e-4)
mu, Sigma = x_to_means_and_covs(output, 5)
print('new default threshold of 1e-6 (not passed)')
print(Sigma)

kwargs_sqrtm={'threshold' : 1e-4}
output = bures.barycenter(weights, xs, kwargs_sqrtm=kwargs_sqrtm)
mu, Sigma = x_to_means_and_covs(output, 5)
print('with former threshold in sqrtm (1e-4), convergence issues')
print(Sigma)

print('groundtruth')
print(jnp.diag(
  (weights[0]*jnp.sqrt(r) + weights[1]*jnp.sqrt(s))**2)
  )
```

outputting
```
new default threshold of 1e-6 (not passed)
[[0.31478475 0.         0.         0.         0.        ]
 [0.         0.87008681 0.         0.         0.        ]
 [0.         0.         0.11116755 0.         0.        ]
 [0.         0.         0.         0.00528754 0.        ]
 [0.         0.         0.         0.         0.93441411]]
with former threshold in sqrtm (1e-4), convergence issues
[[0.31478475 0.         0.         0.         0.        ]
 [0.         0.87008681 0.         0.         0.        ]
 [0.         0.         0.11116755 0.         0.        ]
 [0.         0.         0.         0.         0.        ]
 [0.         0.         0.         0.         0.93441411]]
groundtruth
[[0.31478475 0.         0.         0.         0.        ]
 [0.         0.87008681 0.         0.         0.        ]
 [0.         0.         0.11116755 0.         0.        ]
 [0.         0.         0.         0.0052878  0.        ]
 [0.         0.         0.         0.         0.93441411]]
```