### PR TITLE
feat: add progress reporting to Sinkhorn

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ Packages
   between GMMs, or computing differentiable sort and quantile operations
   :cite:`cuturi:19`.
 - :doc:`math` holds low-level mathematical primitives.
+- :doc:`utils` provides misc helper functions
 
 .. toctree::
     :maxdepth: 1
@@ -102,6 +103,7 @@ Packages
     initializers/index
     tools
     math
+    utils
 
 .. toctree::
     :maxdepth: 1

--- a/docs/solvers/linear.rst
+++ b/docs/solvers/linear.rst
@@ -12,6 +12,7 @@ Sinkhorn Solvers
 
     sinkhorn.solve
     sinkhorn.Sinkhorn
+    sinkhorn.SinkhornState
     sinkhorn.SinkhornOutput
     sinkhorn_lr.LRSinkhorn
     sinkhorn_lr.LRSinkhornOutput

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,0 +1,14 @@
+ott.utils
+=========
+.. currentmodule:: ott
+.. automodule:: ott
+
+The utils package contains misc functions such as signaling deprecations
+or providing an example progress callback function.
+
+Utilities
+---------
+.. autosummary::
+    :toctree: _autosummary
+
+    utils.default_progress_fn

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 __all__ = ["Sinkhorn", "SinkhornOutput", "solve"]
 
 ProgressCallbackFn_t = Callable[
-    [Tuple[np.ndarray, np.ndarray, np.ndarray, NamedTuple]], None]
+    [Tuple[np.ndarray, np.ndarray, np.ndarray, "SinkhornState"]], None]
 
 
 class SinkhornState(NamedTuple):
@@ -650,17 +650,6 @@ class Sinkhorn:
       reflects that these gradients are undefined, since these points were not
       considered in the optimization and have therefore no impact on the output.
 
-  Note:
-    * The optional user-provided callback function ``progress_fn`` is called
-      during solver iterations via :func:`~jax.experimental.host_callback.id_tap`
-      so the solver execution remains jittable. The first 3 arguments are each
-      automatically wrapped by Jax in a ``numpy.ndarray``:
-        - the current iteration
-        - the number of iterations after which the error is computed: is equal
-          to ``inner_iterations``
-        - the maximum number of iterations
-        - the current ``SinkhornState``.
-
   Args:
     lse_mode: ``True`` for log-sum-exp computations, ``False`` for kernel
       multiplication.
@@ -698,10 +687,10 @@ class Sinkhorn:
       when the algorithm has converged with a low tolerance.
     jit: Whether to jit the iteration loop.
     initializer: how to compute the initial potentials/scalings.
-    progress_fn: an optional callback function of type ``ProgressCallbackFn_t``
-      which gets called during Sinkhorn iterations, so the user can display
-      the error at each iteration, e.g. using a progress bar. See
-      :func:``ott.utils.example_progress_callback_fn`` for a basic implementation.
+    progress_fn: callback function which gets called during the Sinkhorn
+      iterations, so the user can display the error at each iteration,
+      e.g., using a progress bar. See :func:`~ott.utils.default_progress_fn`
+      for a basic implementation.
     kwargs_init: keyword arguments when creating the initializer.
   """
 

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -701,7 +701,8 @@ class Sinkhorn:
     initializer: how to compute the initial potentials/scalings.
     progress_fn: an optional callback function of type ``ProgressCallbackFn``
       which gets called during Sinkhorn iterations so the user can display
-      the error at each iteration, e.g. using a progress bar.
+      the error at each iteration, e.g. using a progress bar. See
+      ``ott.utils.example_progress_callback_fn`` for basic implementation.
     kwargs_init: keyword arguments when creating the initializer.
   """
 

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -15,14 +15,11 @@
 import dataclasses
 import functools
 import warnings
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, NamedTuple, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-
-from ott.solvers.linear.sinkhorn import SinkhornState
-from ott.solvers.linear.sinkhorn_lr import LRSinkhornState
 
 __all__ = ["register_pytree_node", "deprecate", "is_jax_array"]
 
@@ -67,8 +64,7 @@ def is_jax_array(obj: Any) -> bool:
 
 
 def default_progress_fn(
-    status: Tuple[np.ndarray, np.ndarray, np.ndarray,
-                  Union[SinkhornState, LRSinkhornState]], *args
+    status: Tuple[np.ndarray, np.ndarray, np.ndarray, NamedTuple], *args
 ) -> None:
   """This default callback function reports progress by printing to the console.
 

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -63,10 +63,10 @@ def is_jax_array(obj: Any) -> bool:
   return isinstance(obj, jnp.DeviceArray)
 
 
-def default_progress_fn(
+def example_progress_callback_fn(
     status: Tuple[np.ndarray, np.ndarray, np.ndarray, NamedTuple], *args
 ) -> None:
-  """This default callback function reports progress by printing to the console.
+  """This callback function reports progress by printing to the console.
 
   Args:
       status: tuple describing the current iteration number,
@@ -78,9 +78,10 @@ def default_progress_fn(
   This function updates the progress bar only when the error is computed
   (every `solver.inner_iterations`, typically `10`).
 
-  Note: the user can provide a slightly modified version of this callback in
-  order to use a progress bar. To do so, replace the print statement with the
-  following:
+  Note:
+      The user can provide a slightly modified version of this callback in
+      order to use a progress bar. To do so, replace the print statement with the
+      following:
 
     ```
     pbar.set_description_str(f"error: {error:.6f}")

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -100,15 +100,18 @@ def default_progress_fn(
     .. code-block:: python
 
       import jax
-      from ott.solvers.linear import sinkhorn
+      import numpy as np
       from tqdm import tqdm
+
+      from ott.problems.linear import linear_problem
+      from ott.solvers.linear import sinkhorn
 
       def progress_fn(status, *args):
         iteration, inner_iterations, total_iter, state = status
         iteration = int(iteration)
         inner_iterations = int(inner_iterations)
         total_iter = int(total_iter)
-        errors = np.array(state.errors).ravel()
+        errors = np.asarray(state.errors).ravel()
 
         # Avoid reporting error on each iteration,
         # because errors are only computed every `inner_iterations`.
@@ -116,15 +119,15 @@ def default_progress_fn(
           error_idx = max((iteration + 1) // inner_iterations - 1, 0)
           error = errors[error_idx]
 
-          pbar.set_description_str(f"error: {error:.6f}")
+          pbar.set_postfix_str(f"error: {error:0.6e}")
           pbar.total = total_iter
           pbar.update()
 
-      lin_problem = ...
+      prob = linear_problem.LinearProblem(...)
       solver = sinkhorn.Sinkhorn(progress_fn=progress_fn)
 
       with tqdm() as pbar:
-        out_sink = jax.jit(solver)(lin_problem)
+        out_sink = jax.jit(solver)(prob)
   """
   # Convert arguments.
   iteration, inner_iterations, total_iter, state = status

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for Sinkhorn."""
-from typing import Optional
+from typing import Optional, Tuple
 
 import pytest
 
@@ -537,3 +537,36 @@ class TestSinkhorn:
     f_mean = jnp.mean(jnp.where(jnp.isfinite(f), f, 0.))
 
     np.testing.assert_allclose(f_mean, 0., rtol=1e-6, atol=1e-6)
+
+  @pytest.mark.fast()
+  def test_callback_fn(self,):
+    """Two point clouds, tested with various parameters."""
+
+    traced_values = {"iters": [], "error": [], "total": []}
+
+    def progress_fn(
+        status: Tuple[np.ndarray, np.ndarray, np.ndarray,
+                      sinkhorn.SinkhornState], *args
+    ) -> None:
+      # Convert arguments.
+      iteration, inner_iterations, total_iter, state = status
+      iteration = int(iteration)
+      inner_iterations = int(inner_iterations)
+      total_iter = int(total_iter)
+      errors = np.array(state.errors).ravel()
+
+      # Avoid reporting error on each iteration,
+      # because errors are only computed every `inner_iterations`.
+      if (iteration + 1) % inner_iterations == 0:
+        error_idx = max((iteration + 1) // inner_iterations - 1, 0)
+        error = errors[error_idx]
+
+        traced_values["iters"].append(iteration)
+        traced_values["error"].append(error)
+        traced_values["total"].append(total_iter)
+
+    geom = pointcloud.PointCloud(self.x, self.y, epsilon=0.1)
+    lin_prob = linear_problem.LinearProblem(geom, a=self.a, b=self.b)
+    _ = sinkhorn.Sinkhorn(progress_fn=progress_fn, max_iterations=4)(lin_prob)
+
+    assert traced_values["iters"] == [0, 1, 2, 3]

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -540,7 +540,7 @@ class TestSinkhorn:
 
   @pytest.mark.fast()
   def test_callback_fn(self,):
-    """Two point clouds, tested with various parameters."""
+    """Check that the callback function is actually called."""
 
     traced_values = {"iters": [], "error": [], "total": []}
 
@@ -567,6 +567,13 @@ class TestSinkhorn:
 
     geom = pointcloud.PointCloud(self.x, self.y, epsilon=0.1)
     lin_prob = linear_problem.LinearProblem(geom, a=self.a, b=self.b)
-    _ = sinkhorn.Sinkhorn(progress_fn=progress_fn, max_iterations=4)(lin_prob)
+    _ = sinkhorn.Sinkhorn(
+        progress_fn=progress_fn, max_iterations=10 * 2
+    )(
+        lin_prob
+    )
 
-    assert traced_values["iters"] == [0, 1, 2, 3]
+    assert traced_values["iters"] == [9, 19]
+    assert pytest.approx(traced_values["error"][0], 1e-5) == 0.003072811
+    assert pytest.approx(traced_values["error"][1], 1e-5) == 5.9314094e-05
+    assert traced_values["total"] == [20, 20]


### PR DESCRIPTION
Hi,

Following https://github.com/ott-jax/ott/issues/210, here is a PoC for adding progress report to various solvers in OTT-jax. This PR focuses first on the `Sinkhorn` solver, but `LRSinkhorn` and others can follow if all goes fine.

## How a user uses it

A user who wants to benefit from this feature simply needs to provide a callback function to the `sinkhorn.Sinkhorn(progress_fn=myfunc)`. The callback func signature should be

```python
def progress_fn(status: Tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]], *args) -> None:
```

This callback function can do whatever side effects the user wants, such as printing or updating a tqdm progress bar.

## How it works

The user provided function is provided to the `Sinkhorn` initializer and stored in the instance, and gets called on each Sinkhorn iteration via the dedicated jax `host_callback` mechanism (see [here](https://jax.readthedocs.io/en/latest/jax.experimental.host_callback.html)).

## Examples

Here is a very basic example:

```python
def progress_fn(status: Tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]], *args) -> None:
    """
    Report progress.
    
    Args:
        status: tuple describing the current iteration number wrapped in a jax.Array,
            the optional total number of iterations wrapped in a jax.Array, and an array
            of errors.
          
    For iterative algorithms, the actual number of iterations needed to reach convergence
    is unknown beforehand. Depending on the use case, the value may be represented as None
    or have a default value.
          
    """
    iteration, total_iter, error = status
    iteration = np.array(iteration).sum()

    if error is not None:
        error = np.array(error).ravel()[-1]
        pbar.set_description_str(f"error: {error}")
    
    if total_iter is not None:
        total_iter = np.array(total_iter).sum()
        pbar.total = total_iter
        
    pbar.update()

    # alternatively:
    # print(f"Iteration {iteration} / {total_iter}")
```

and here is how it looks like at the call site:

```python
from tqdm import tqdm
with tqdm() as pbar:
    out_sink = jax.jit(sinkhorn.Sinkhorn(progress_fn=progress_fn))(lin_p)
```

<img width="968" alt="image" src="https://user-images.githubusercontent.com/1936828/210862963-df00d765-3715-4583-9ef7-4bb81a9b6e21.png">
