### PR TITLE
chore: add yapf config to `pyproject.toml`

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,8 +1,0 @@
-[style]
-based_on_style: yapf
-column_limit: 80
-indent_width: 2
-split_before_named_assigns: True
-spaces_around_power_operator: True
-dedent_closing_brackets: True
-coalesce_brackets: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,12 @@ precision = 2
 show_missing = true
 skip_empty = true
 sort = "Miss"
+
+[tool.yapf]
+based_on_style = "yapf"
+column_limit = 80
+indent_width = 2
+split_before_named_assigns = true
+spaces_around_power_operator = true
+dedent_closing_brackets = true
+coalesce_brackets = true


### PR DESCRIPTION
This PR aims to drop the `.style.yapf` file in favour of `pyproject.toml` in order to have a more minimal project structure.

**Reference:** Following https://github.com/google/yapf/issues/708, `pyproject.toml` support was added.