### PR TITLE
add `primal_cost` property to output of GW, to compute cost without any regularization.

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -195,15 +195,13 @@
  copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
-@Misc{bunne:22,
- doi = {10.48550/ARXIV.2206.14262},
- url = {https://arxiv.org/abs/2206.14262},
- author = {Bunne, Charlotte and Krause, Andreas and Cuturi, Marco},
- keywords = {Machine Learning (cs.LG), FOS: Computer and information sciences, FOS: Computer and information sciences},
- title = {Supervised Training of Conditional Monge Maps},
- publisher = {arXiv},
- year = {2022},
- copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+@inproceedings{bunne:22,
+title={Supervised Training of Conditional Monge Maps},
+author={Charlotte Bunne and Andreas Krause and marco cuturi},
+booktitle={Advances in Neural Information Processing Systems},
+editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
+year={2022},
+url={https://openreview.net/forum?id=sPNtVVUq7wi}
 }
 
 @Article{gelbrich:90,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -196,12 +196,12 @@
 }
 
 @inproceedings{bunne:22,
-title={Supervised Training of Conditional Monge Maps},
-author={Charlotte Bunne and Andreas Krause and marco cuturi},
-booktitle={Advances in Neural Information Processing Systems},
-editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
-year={2022},
-url={https://openreview.net/forum?id=sPNtVVUq7wi}
+  title={Supervised Training of Conditional Monge Maps},
+  author={Charlotte Bunne and Andreas Krause and marco cuturi},
+  booktitle={Advances in Neural Information Processing Systems},
+  editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
+  year={2022},
+  url={https://openreview.net/forum?id=sPNtVVUq7wi}
 }
 
 @Article{gelbrich:90,

--- a/src/ott/problems/quadratic/quadratic_problem.py
+++ b/src/ott/problems/quadratic/quadratic_problem.py
@@ -139,7 +139,7 @@ class QuadraticProblem:
     Uses the first term in eq. 6, p. 1 of :cite:`peyre:16`.
 
     Let :math:`p` be the `[n,]` marginal of the transport matrix for samples
-    from :attr:`geom_xx``geom_xx` and :math:`q` the `[m,]` marginal of the
+    from :attr:`geom_xx` and :math:`q` the `[m,]` marginal of the
     transport matrix for samples from :attr:`geom_yy`.
 
     When ``cost_xx`` (resp. ``cost_yy``) is the cost matrix of :attr:`geom_xx`

--- a/src/ott/problems/quadratic/quadratic_problem.py
+++ b/src/ott/problems/quadratic/quadratic_problem.py
@@ -144,13 +144,15 @@ class QuadraticProblem:
     cost matrix of `geom_xx` (resp. `geom_yy`). The cost term that
     depends on these marginals can be written as:
 
-    `marginal_dep_term` = `lin1`(`cost_xx`) :math:`p \mathbb{1}_{num_b}^T`
-                      + (`lin2`(`cost_yy`) :math:`q \mathbb{1}_{num_a}^T)^T`
+    .. math::
+    
+      \text{marginal_dep_term} = \text{lin1}(\text{cost_xx}) p \mathbb{1}_{m}^T`
+                      + \text{lin2}(\text{cost_yy}) q \mathbb{1}_{n}^T)^T`
 
     Args:
-      marginal_1: jnp.ndarray<float>[num_a,], marginal of the transport matrix
+      marginal_1: jnp.ndarray<float>[n,], marginal of the transport matrix
        for samples from geom_xx
-      marginal_2: jnp.ndarray<float>[num_b,], marginal of the transport matrix
+      marginal_2: jnp.ndarray<float>[m,], marginal of the transport matrix
        for samples from geom_yy
 
     Returns:

--- a/src/ott/problems/quadratic/quadratic_problem.py
+++ b/src/ott/problems/quadratic/quadratic_problem.py
@@ -138,22 +138,25 @@ class QuadraticProblem:
 
     Uses the first term in eq. 6, p. 1 of :cite:`peyre:16`.
 
-    Let :math:`p` [num_a,] be the marginal of the transport matrix for samples
-    from `geom_xx` and :math:`q` [num_b,] be the marginal of the transport
-    matrix for samples from `geom_yy`. `cost_xx` (resp. `cost_yy`) is the
-    cost matrix of `geom_xx` (resp. `geom_yy`). The cost term that
-    depends on these marginals can be written as:
+    Let :math:`p` be the `[n,]` marginal of the transport matrix for samples
+    from `geom_xx` and :math:`q` the `[m,]` marginal of the transport
+    matrix for samples from `geom_yy`.
+
+    When `cost_xx` (resp. `cost_yy`) is the cost matrix of `geom_xx`
+    (resp. `geom_yy`). The cost term that depends on these marginals can be
+    written as:
 
     .. math::
 
-      \text{marginal_dep_term} = \text{lin1}(\text{cost_xx}) p \mathbb{1}_{m}^T`
-                      + \text{lin2}(\text{cost_yy}) q \mathbb{1}_{n}^T)^T`
+      \text{marginal_dep_term} = \text{lin1}(\text{cost_xx}) p \mathbb{1}_{m}^T
+                      + \text{lin2}(\text{cost_yy}) q \mathbb{1}_{n}^T)^T
+
+    This helper function instantiates these two low-rank matrices and groups
+    them into a single low-rank cost geometry object.
 
     Args:
-      marginal_1: jnp.ndarray<float>[n,], marginal of the transport matrix
-       for samples from geom_xx
-      marginal_2: jnp.ndarray<float>[m,], marginal of the transport matrix
-       for samples from geom_yy
+      marginal_1: [n,], marginal of transport matrix for samples in `geom_xx`.
+      marginal_2: [m,], marginal of transport matrix for samples in `geom_yy`.
 
     Returns:
       Low-rank geometry.

--- a/src/ott/problems/quadratic/quadratic_problem.py
+++ b/src/ott/problems/quadratic/quadratic_problem.py
@@ -145,7 +145,7 @@ class QuadraticProblem:
     depends on these marginals can be written as:
 
     .. math::
-    
+
       \text{marginal_dep_term} = \text{lin1}(\text{cost_xx}) p \mathbb{1}_{m}^T`
                       + \text{lin2}(\text{cost_yy}) q \mathbb{1}_{n}^T)^T`
 

--- a/src/ott/problems/quadratic/quadratic_problem.py
+++ b/src/ott/problems/quadratic/quadratic_problem.py
@@ -139,27 +139,27 @@ class QuadraticProblem:
     Uses the first term in eq. 6, p. 1 of :cite:`peyre:16`.
 
     Let :math:`p` be the `[n,]` marginal of the transport matrix for samples
-    from `geom_xx` and :math:`q` the `[m,]` marginal of the transport
-    matrix for samples from `geom_yy`.
+    from :attr:`geom_xx``geom_xx` and :math:`q` the `[m,]` marginal of the
+    transport matrix for samples from :attr:`geom_yy`.
 
-    When `cost_xx` (resp. `cost_yy`) is the cost matrix of `geom_xx`
-    (resp. `geom_yy`). The cost term that depends on these marginals can be
-    written as:
+    When ``cost_xx`` (resp. ``cost_yy``) is the cost matrix of :attr:`geom_xx`
+    (resp. :attr:`geom_yy`), the cost term that depends on these marginals can
+    be written as:
 
     .. math::
 
       \text{marginal_dep_term} = \text{lin1}(\text{cost_xx}) p \mathbb{1}_{m}^T
-                      + \text{lin2}(\text{cost_yy}) q \mathbb{1}_{n}^T)^T
+                      +  \mathbb{1}_{n}(\text{lin2}(\text{cost_yy}) q)^T
 
     This helper function instantiates these two low-rank matrices and groups
     them into a single low-rank cost geometry object.
 
     Args:
-      marginal_1: [n,], marginal of transport matrix for samples in `geom_xx`.
-      marginal_2: [m,], marginal of transport matrix for samples in `geom_yy`.
+      marginal_1: [n,], first marginal of transport matrix.
+      marginal_2: [m,], second marginal of transport matrix.
 
     Returns:
-      Low-rank geometry.
+      Low-rank geometry of rank 2, storing normalization constants.
     """
     if self._loss_name == 'sqeucl':  # quadratic apply, efficient for LR
       tmp1 = self.geom_xx.apply_square_cost(marginal_1, axis=1)

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -308,7 +308,7 @@ class SinkhornOutput(NamedTuple):
     return dual_cost
 
   @property
-  def primal_cost(self) -> jnp.ndarray:
+  def primal_cost(self) -> float:
     """Return transport cost of current solution at geometry."""
     return self.transport_cost_at_geom(other_geom=self.geom)
 

--- a/src/ott/solvers/linear/sinkhorn_lr.py
+++ b/src/ott/solvers/linear/sinkhorn_lr.py
@@ -196,7 +196,7 @@ class LRSinkhornOutput(NamedTuple):
     return self.cost_at_geom(other_geom)
 
   @property
-  def primal_cost(self) -> jnp.ndarray:
+  def primal_cost(self) -> float:
     """Return (by recomputing it) transport cost of current solution."""
     return self.transport_cost_at_geom(other_geom=self.geom)
 

--- a/src/ott/solvers/quadratic/gromov_wasserstein.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein.py
@@ -89,6 +89,10 @@ class GWOutput(NamedTuple):
   def _rescale_factor(self) -> float:
     return jnp.sqrt(self.old_transport_mass / self.linear_state.transport_mass)
 
+  @property
+  def primal_cost(self) -> float:
+    """Return transport cost of current linear OT solution at geometry."""
+    return self.linear_state.transport_cost_at_geom(other_geom=self.geom)
 
 class GWState(NamedTuple):
   """Holds the state of the Gromov-Wasserstein solver.

--- a/src/ott/solvers/quadratic/gromov_wasserstein.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein.py
@@ -94,6 +94,7 @@ class GWOutput(NamedTuple):
     """Return transport cost of current linear OT solution at geometry."""
     return self.linear_state.transport_cost_at_geom(other_geom=self.geom)
 
+
 class GWState(NamedTuple):
   """Holds the state of the Gromov-Wasserstein solver.
 

--- a/tests/solvers/quadratic/gw_test.py
+++ b/tests/solvers/quadratic/gw_test.py
@@ -207,14 +207,9 @@ class TestGromovWasserstein:
     prob = quadratic_problem.QuadraticProblem(
         geom_x, geom_y, a=self.a, b=self.b, tau_a=tau_a, tau_b=tau_b
     )
-    if rank > 0:
-      solver = gromov_wasserstein.GromovWasserstein(
-          rank=rank, max_iterations=10
-      )
-    else:
-      solver = gromov_wasserstein.GromovWasserstein(
-          epsilon=1.0, max_iterations=10
-      )
+    solver = gromov_wasserstein.GromovWasserstein(
+        rank=rank, epsilon=0.0 if rank > 0 else 1.0, max_iterations=10
+    )
 
     out = solver(prob)
     # TODO(cuturi): test primal cost for un-balanced case as well.

--- a/tests/solvers/quadratic/gw_test.py
+++ b/tests/solvers/quadratic/gw_test.py
@@ -196,39 +196,39 @@ class TestGromovWasserstein:
     )
 
   @pytest.mark.fast
-  @pytest.mark.parametrize("unbalanced", [False, True])
-  def test_gw_pointcloud(self, unbalanced: bool):
+  @pytest.mark.parametrize(
+      "balanced,rank", [(True, -1), (False, -1), (True, 3)]
+  )
+  def test_gw_pointcloud(self, balanced: bool, rank: int):
     """Test basic computations pointclouds."""
     geom_x = pointcloud.PointCloud(self.x)
     geom_y = pointcloud.PointCloud(self.y)
-    tau_a, tau_b = (self.tau_a, self.tau_b) if unbalanced else (1.0, 1.0)
+    tau_a, tau_b = (1.0, 1.0) if balanced else (self.tau_a, self.tau_b)
     prob = quadratic_problem.QuadraticProblem(
         geom_x, geom_y, a=self.a, b=self.b, tau_a=tau_a, tau_b=tau_b
     )
-    solver_ent = gromov_wasserstein.GromovWasserstein(
-        epsilon=1.0, max_iterations=10
-    )
-    solvers = [
-        solver_ent,
-    ]
-    if not unbalanced:
-      # LR Sinkhorn only implemented in balanced case.
-      solver_lr = gromov_wasserstein.GromovWasserstein(
-          rank=3, max_iterations=10
+    if rank > 0:
+      solver = gromov_wasserstein.GromovWasserstein(
+          rank=rank, max_iterations=10
       )
-      solvers.append(solver_lr)
+    else:
+      solver = gromov_wasserstein.GromovWasserstein(
+          epsilon=1.0, max_iterations=10
+      )
 
-    for solver in solvers:
-      out = solver(prob)
+    out = solver(prob)
+    # TODO(cuturi): test primal cost for un-balanced case as well.
+    if balanced:
       u = geom_x.apply_square_cost(out.matrix.sum(axis=-1)).squeeze()
       v = geom_y.apply_square_cost(out.matrix.sum(axis=0)).squeeze()
       c = (geom_x.cost_matrix @ out.matrix) @ geom_y.cost_matrix
       c = (u[:, None] + v[None, :] - 2 * c)
-      if not unbalanced:
-        # Formula above is only valid for balanced case.
-        assert np.isclose(out.primal_cost, jnp.sum(c * out.matrix), rtol=1e-3)
 
-      assert not jnp.isnan(out.reg_gw_cost)
+      np.testing.assert_allclose(
+          out.primal_cost, jnp.sum(c * out.matrix), rtol=1e-3
+      )
+
+    assert not jnp.isnan(out.reg_gw_cost)
 
   @pytest.mark.parametrize(
       "unbalanced,unbalanced_correction", [(False, False), (True, False),

--- a/tests/solvers/quadratic/gw_test.py
+++ b/tests/solvers/quadratic/gw_test.py
@@ -206,16 +206,16 @@ class TestGromovWasserstein:
         geom_x, geom_y, a=self.a, b=self.b, tau_a=tau_a, tau_b=tau_b
     )
     solver_ent = gromov_wasserstein.GromovWasserstein(
-      epsilon=1.0, max_iterations=10)
-    solver_lr = gromov_wasserstein.GromovWasserstein(
-      rank=3, max_iterations=10)
-    
+        epsilon=1.0, max_iterations=10
+    )
+    solver_lr = gromov_wasserstein.GromovWasserstein(rank=3, max_iterations=10)
+
     for solver in (solver_ent, solver_lr):
       out = solver(prob)
       u = geom_x.apply_square_cost(out.matrix.sum(axis=-1)).squeeze()
       v = geom_y.apply_square_cost(out.matrix.sum(axis=0)).squeeze()
       c = (geom_x.cost_matrix @ out.matrix) @ geom_y.cost_matrix
-      c = (u[:,None] + v[None,:] - 2 * c)
+      c = (u[:, None] + v[None, :] - 2 * c)
       if not unbalanced:
         assert np.isclose(out.primal_cost, jnp.sum(c * out.matrix), rtol=1e-3)
       assert not jnp.isnan(out.reg_gw_cost)


### PR DESCRIPTION
Adds a `primal_cost` property to the output of a GW solver (regular and LR), solves #186 