### PR TITLE
feat: Improve Type Hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "jax>=0.4.4",
-    "jaxlib>=0.1.47",
+    "jaxlib>=0.4.4",
     "jaxopt>=0.5.5",
     # https://github.com/google/jax/discussions/9951#discussioncomment-3017784
     "numpy>=1.18.4, !=1.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {name = "OTT team", email = "optimal.transport.tools@gmail.com"}
 ]
 dependencies = [
-    "jax>=0.1.67",
+    "jax>=0.4.4",
     "jaxlib>=0.1.47",
     "jaxopt>=0.5.5",
     # https://github.com/google/jax/discussions/9951#discussioncomment-3017784

--- a/src/ott/geometry/epsilon_scheduler.py
+++ b/src/ott/geometry/epsilon_scheduler.py
@@ -49,7 +49,7 @@ class Epsilon:
       scale_epsilon: Optional[float] = None,
       init: float = 1.0,
       decay: float = 1.0
-  ):
+  ) -> None:
     self._target_init = target
     self._scale_epsilon = scale_epsilon
     self._init = init

--- a/src/ott/geometry/segment.py
+++ b/src/ott/geometry/segment.py
@@ -16,20 +16,21 @@ from typing import Callable, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 __all__ = ["segment_point_cloud"]
 
 
 def segment_point_cloud(
-    x: jnp.ndarray,
-    a: Optional[jnp.ndarray] = None,
+    x: ArrayLike,
+    a: Optional[ArrayLike] = None,
     num_segments: Optional[int] = None,
     max_measure_size: Optional[int] = None,
-    segment_ids: Optional[jnp.ndarray] = None,
+    segment_ids: Optional[ArrayLike] = None,
     indices_are_sorted: bool = False,
     num_per_segment: Optional[Tuple[int, ...]] = None,
-    padding_vector: Optional[jnp.ndarray] = None
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    padding_vector: Optional[ArrayLike] = None
+) -> Tuple[Array, Array]:
   """Segment and pad as needed the entries of a point cloud.
 
   There are two interfaces:
@@ -45,10 +46,10 @@ def segment_point_cloud(
   upper bound on the maximal size of measures, which will be used for padding.
 
   Args:
-    x: Array of input points, of shape ``[num_x, ndim]``.
+    x: ArrayLike of input points, of shape ``[num_x, ndim]``.
       Multiple segments are held in this single array.
-    a: Array of shape ``[num_x,]`` containing the weights (within each measure)
-      of all the points.
+    a: ArrayLike of shape ``[num_x,]`` containing the weights
+      (within each measure) of all the points.
     num_segments: Number of segments. Required for jitting.
       If `None` and using the second interface, it will be computed as
       ``len(num_per_segment)``.
@@ -129,21 +130,20 @@ def segment_point_cloud(
 
 
 def _segment_interface(
-    x: jnp.ndarray,
-    y: jnp.ndarray,
-    eval_fn: Callable[[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray],
-                      jnp.ndarray],
+    x: ArrayLike,
+    y: ArrayLike,
+    eval_fn: Callable[[ArrayLike, ArrayLike, ArrayLike, ArrayLike], ArrayLike],
     num_segments: Optional[int] = None,
     max_measure_size: Optional[int] = None,
-    segment_ids_x: Optional[jnp.ndarray] = None,
-    segment_ids_y: Optional[jnp.ndarray] = None,
+    segment_ids_x: Optional[ArrayLike] = None,
+    segment_ids_y: Optional[ArrayLike] = None,
     indices_are_sorted: bool = False,
-    num_per_segment_x: Optional[jnp.ndarray] = None,
-    num_per_segment_y: Optional[jnp.ndarray] = None,
-    weights_x: Optional[jnp.ndarray] = None,
-    weights_y: Optional[jnp.ndarray] = None,
-    padding_vector: Optional[jnp.ndarray] = None,
-) -> jnp.ndarray:
+    num_per_segment_x: Optional[ArrayLike] = None,
+    num_per_segment_y: Optional[ArrayLike] = None,
+    weights_x: Optional[ArrayLike] = None,
+    weights_y: Optional[ArrayLike] = None,
+    padding_vector: Optional[ArrayLike] = None,
+) -> Array:
   """Wrapper to segment two point clouds and return parallel evaluations.
 
   Utility function that segments two point clouds using the approach outlined

--- a/src/ott/initializers/quadratic/initializers.py
+++ b/src/ott/initializers/quadratic/initializers.py
@@ -35,7 +35,7 @@ class BaseQuadraticInitializer(abc.ABC):
     kwargs: Keyword arguments.
   """
 
-  def __init__(self, **kwargs: Any):
+  def __init__(self, **kwargs: Any) -> None:
     self._kwargs = kwargs
 
   def __call__(
@@ -171,7 +171,9 @@ class LRQuadraticInitializer(BaseQuadraticInitializer):
     lr_linear_initializer: Low-rank linear initializer.
   """
 
-  def __init__(self, lr_linear_initializer: "initializers_lr.LRInitializer"):
+  def __init__(
+      self, lr_linear_initializer: "initializers_lr.LRInitializer"
+  ) -> None:
     super().__init__()
     self._linear_lr_initializer = lr_linear_initializer
 

--- a/src/ott/math/unbalanced_functions.py
+++ b/src/ott/math/unbalanced_functions.py
@@ -14,22 +14,23 @@
 from typing import Callable
 
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 
-def phi_star(h: jnp.ndarray, rho: float) -> jnp.ndarray:
+def phi_star(h: ArrayLike, rho: float) -> Array:
   """Legendre transform of KL, :cite:`sejourne:19`, p. 9."""
   return rho * (jnp.exp(h / rho) - 1)
 
 
 # TODO(cuturi): use jax.grad directly.
-def derivative_phi_star(f: jnp.ndarray, rho: float) -> jnp.ndarray:
+def derivative_phi_star(f: ArrayLike, rho: float) -> Array:
   """Derivative of Legendre transform of phi_starKL, see phi_star."""
   return jnp.exp(f / rho)
 
 
 def grad_of_marginal_fit(
-    c: jnp.ndarray, h: jnp.ndarray, tau: float, epsilon: float
-) -> jnp.ndarray:
+    c: ArrayLike, h: ArrayLike, tau: float, epsilon: float
+) -> Array:
   """Compute grad of terms linked to marginals in objective.
 
   Computes gradient w.r.t. f ( or g) of terms in :cite:`sejourne:19`,
@@ -50,15 +51,15 @@ def grad_of_marginal_fit(
   return jnp.where(c > 0, c * derivative_phi_star(-h, r), 0.0)
 
 
-def second_derivative_phi_star(f: jnp.ndarray, rho: float) -> jnp.ndarray:
+def second_derivative_phi_star(f: ArrayLike, rho: float) -> Array:
   """Second Derivative of Legendre transform of KL, see phi_star."""
   return jnp.exp(f / rho) / rho
 
 
 def diag_jacobian_of_marginal_fit(
-    c: jnp.ndarray, h: jnp.ndarray, tau: float, epsilon: float,
-    derivative: Callable[[jnp.ndarray, float], jnp.ndarray]
-):
+    c: ArrayLike, h: ArrayLike, tau: float, epsilon: float,
+    derivative: Callable[[ArrayLike, float], ArrayLike]
+) -> Array:
   """Compute grad of terms linked to marginals in objective.
 
   Computes second derivative w.r.t. f ( or g) of terms in :cite:`sejourne:19`,

--- a/src/ott/problems/linear/barycenter_problem.py
+++ b/src/ott/problems/linear/barycenter_problem.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import costs, geometry, segment
 
@@ -56,14 +57,14 @@ class FreeBarycenterProblem:
 
   def __init__(
       self,
-      y: jnp.ndarray,
-      b: Optional[jnp.ndarray] = None,
-      weights: Optional[jnp.ndarray] = None,
+      y: ArrayLike,
+      b: Optional[ArrayLike] = None,
+      weights: Optional[ArrayLike] = None,
       cost_fn: Optional[costs.CostFn] = None,
       epsilon: Optional[float] = None,
       debiased: bool = False,
       **kwargs: Any,
-  ):
+  ) -> None:
     self._y = y
     if y.ndim == 3 and b is None:
       raise ValueError("Specify weights if `y` is already segmented.")
@@ -84,7 +85,7 @@ class FreeBarycenterProblem:
       assert self._b is None or self._y.shape[0] == self._b.shape[0]
 
   @property
-  def segmented_y_b(self) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  def segmented_y_b(self) -> Tuple[Array, Array]:
     """Tuple of arrays containing the segmented measures and weights.
 
     Additional segment may be added when the problem is debiased.
@@ -107,9 +108,8 @@ class FreeBarycenterProblem:
     return y, b
 
   @staticmethod
-  def _add_slice_for_debiased(
-      y: jnp.ndarray, b: jnp.ndarray
-  ) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  def _add_slice_for_debiased(y: ArrayLike,
+                              b: ArrayLike) -> Tuple[Array, Array]:
     _, n, ndim = y.shape  # (num_measures, max_measure_size, ndim)
     # yapf: disable
     y = jnp.concatenate((y, jnp.zeros((1, n, ndim))), axis=0)
@@ -118,14 +118,14 @@ class FreeBarycenterProblem:
     return y, b
 
   @property
-  def flattened_y(self) -> jnp.ndarray:
+  def flattened_y(self) -> Array:
     """Array of shape ``[num_measures * (N_1 + N_2 + ...), ndim]``."""
     if self._is_segmented:
       return self._y.reshape((-1, self._y.shape[-1]))
     return self._y
 
   @property
-  def flattened_b(self) -> Optional[jnp.ndarray]:
+  def flattened_b(self) -> Optional[Array]:
     """Array of shape ``[num_measures * (N_1 + N_2 + ...),]``."""
     return None if self._b is None else self._b.ravel()
 
@@ -145,7 +145,7 @@ class FreeBarycenterProblem:
     return self._y.shape[-1]
 
   @property
-  def weights(self) -> jnp.ndarray:
+  def weights(self) -> Array:
     """Barycenter weights of shape ``[num_measures,]`` that sum to 1."""
     if self._weights is None:
       weights = jnp.ones((self.num_measures,)) / self.num_measures
@@ -194,9 +194,9 @@ class FixedBarycenterProblem:
   def __init__(
       self,
       geom: geometry.Geometry,
-      a: jnp.ndarray,
-      weights: Optional[jnp.ndarray] = None,
-  ):
+      a: ArrayLike,
+      weights: Optional[ArrayLike] = None,
+  ) -> None:
     self.geom = geom
     self.a = a
     self._weights = weights
@@ -207,7 +207,7 @@ class FixedBarycenterProblem:
     return self.a.shape[0]
 
   @property
-  def weights(self) -> jnp.ndarray:
+  def weights(self) -> Array:
     """Barycenter weights of shape ``[num_measures,]`` that sum to :math`1`."""
     if self._weights is None:
       return jnp.ones((self.num_measures,)) / self.num_measures

--- a/src/ott/problems/linear/linear_problem.py
+++ b/src/ott/problems/linear/linear_problem.py
@@ -15,15 +15,15 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import geometry
 
 __all__ = ["LinearProblem"]
 
 # TODO(michalk8): move to typing.py when refactoring the types
-MarginalFunc = Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
-TransportAppFunc = Callable[[jnp.ndarray, jnp.ndarray, jnp.ndarray, int],
-                            jnp.ndarray]
+MarginalFunc = Callable[[ArrayLike, ArrayLike], ArrayLike]
+TransportAppFunc = Callable[[ArrayLike, ArrayLike, ArrayLike, int], ArrayLike]
 
 
 @jax.tree_util.register_pytree_node_class
@@ -50,8 +50,8 @@ class LinearProblem:
   def __init__(
       self,
       geom: geometry.Geometry,
-      a: Optional[jnp.ndarray] = None,
-      b: Optional[jnp.ndarray] = None,
+      a: Optional[ArrayLike] = None,
+      b: Optional[ArrayLike] = None,
       tau_a: float = 1.0,
       tau_b: float = 1.0
   ):
@@ -62,13 +62,13 @@ class LinearProblem:
     self.tau_b = tau_b
 
   @property
-  def a(self) -> jnp.ndarray:
+  def a(self) -> Array:
     """First marginal."""
     num_a = self.geom.shape[0]
     return jnp.ones((num_a,)) / num_a if self._a is None else self._a
 
   @property
-  def b(self) -> jnp.ndarray:
+  def b(self) -> Array:
     """Second marginal."""
     num_b = self.geom.shape[1]
     return jnp.ones((num_b,)) / num_b if self._b is None else self._b

--- a/src/ott/problems/nn/dataset.py
+++ b/src/ott/problems/nn/dataset.py
@@ -15,8 +15,8 @@ import dataclasses
 from typing import Iterator, Literal, NamedTuple, Tuple
 
 import jax
-import jax.numpy as jnp
 import numpy as np
+from jax.typing import Array, ArrayLike
 
 __all__ = ["create_gaussian_mixture_samplers", "Dataset", "GaussianMixture"]
 
@@ -30,8 +30,8 @@ class Dataset(NamedTuple):
     source_iter: loader for the source measure
     target_iter: loader for the target measure
   """
-  source_iter: Iterator[jnp.ndarray]
-  target_iter: Iterator[jnp.ndarray]
+  source_iter: Iterator[ArrayLike]
+  target_iter: Iterator[ArrayLike]
 
 
 @dataclasses.dataclass
@@ -59,7 +59,7 @@ class GaussianMixture:
   scale: float = 5.0
   variance: float = 0.5
 
-  def __post_init__(self):
+  def __post_init__(self) -> None:
     gaussian_centers = {
         "simple":
             np.array([[0, 0]]),
@@ -85,7 +85,7 @@ class GaussianMixture:
       )
     self.centers = gaussian_centers[self.name]
 
-  def __iter__(self) -> Iterator[jnp.array]:
+  def __iter__(self) -> Iterator[ArrayLike]:
     """Random sample generator from Gaussian mixture.
 
     Returns:
@@ -93,7 +93,7 @@ class GaussianMixture:
     """
     return self._create_sample_generators()
 
-  def _create_sample_generators(self) -> Iterator[jnp.array]:
+  def _create_sample_generators(self) -> Iterator[Array]:
     rng = self.init_rng
     while True:
       rng1, rng2, rng = jax.random.split(rng, 3)

--- a/src/ott/problems/quadratic/quadratic_costs.py
+++ b/src/ott/problems/quadratic/quadratic_costs.py
@@ -15,12 +15,13 @@ from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
+from jax.typing import ArrayLike
 
 __all__ = ["make_square_loss", "make_kl_loss"]
 
 
 class Loss(NamedTuple):  # noqa: D101
-  func: Callable[[jnp.ndarray], jnp.ndarray]
+  func: Callable[[ArrayLike], ArrayLike]
   is_linear: bool
 
 

--- a/src/ott/solvers/linear/acceleration.py
+++ b/src/ott/solvers/linear/acceleration.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott import utils
 
@@ -34,7 +35,7 @@ class AndersonAcceleration:
   refresh_every: int = 1  # Recompute interpolation periodically.
   ridge_identity: float = 1e-2  # Ridge used in the linear system.
 
-  def extrapolation(self, xs: jnp.ndarray, fxs: jnp.ndarray) -> jnp.ndarray:
+  def extrapolation(self, xs: ArrayLike, fxs: ArrayLike) -> Array:
     """Compute Anderson extrapolation from past observations."""
     # Remove -inf values to instantiate quadratic problem. All others
     # remain since they might be caused by a valid issue.
@@ -161,10 +162,10 @@ class Momentum:
   def __call__(  # noqa: D102
       self,
       weight: float,
-      value: jnp.ndarray,
-      new_value: jnp.ndarray,
+      value: ArrayLike,
+      new_value: ArrayLike,
       lse_mode: bool = True
-  ) -> jnp.ndarray:
+  ) -> Array:
     if lse_mode:
       value = jnp.where(jnp.isfinite(value), value, 0.0)
       return (1.0 - weight) * value + weight * new_value

--- a/src/ott/solvers/linear/continuous_barycenter.py
+++ b/src/ott/solvers/linear/continuous_barycenter.py
@@ -16,6 +16,7 @@ from typing import Any, NamedTuple, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax.typing import ArrayLike
 
 from ott.geometry import pointcloud
 from ott.math import fixed_point_loop
@@ -40,11 +41,11 @@ class FreeBarycenterState(NamedTuple):
     a: barycenter weights.
   """
 
-  costs: Optional[jnp.ndarray] = None
-  linear_convergence: Optional[jnp.ndarray] = None
-  errors: Optional[jnp.ndarray] = None
-  x: Optional[jnp.ndarray] = None
-  a: Optional[jnp.ndarray] = None
+  costs: Optional[ArrayLike] = None
+  linear_convergence: Optional[ArrayLike] = None
+  errors: Optional[ArrayLike] = None
+  x: Optional[ArrayLike] = None
+  a: Optional[ArrayLike] = None
 
   def set(self, **kwargs: Any) -> "FreeBarycenterState":
     """Return a copy of self, possibly with overwrites."""
@@ -134,7 +135,7 @@ class FreeWassersteinBarycenter(was_solver.WassersteinSolver):
       self,
       bar_prob: barycenter_problem.FreeBarycenterProblem,
       bar_size: int = 100,
-      x_init: Optional[jnp.ndarray] = None,
+      x_init: Optional[ArrayLike] = None,
       rng: jax.random.PRNGKeyArray = jax.random.PRNGKey(0)
   ) -> FreeBarycenterState:
     # TODO(michalk8): no reason for iterations to be outside this class
@@ -145,7 +146,7 @@ class FreeWassersteinBarycenter(was_solver.WassersteinSolver):
       self,
       bar_prob: barycenter_problem.FreeBarycenterProblem,
       bar_size: int,
-      x_init: Optional[jnp.ndarray] = None,
+      x_init: Optional[ArrayLike] = None,
       rng: jax.random.PRNGKeyArray = jax.random.PRNGKey(0),
   ) -> FreeBarycenterState:
     """Initialize the state of the Wasserstein barycenter iterations.
@@ -199,7 +200,7 @@ class FreeWassersteinBarycenter(was_solver.WassersteinSolver):
 
 def iterations(
     solver: FreeWassersteinBarycenter, bar_size: int,
-    bar_prob: barycenter_problem.FreeBarycenterProblem, x_init: jnp.ndarray,
+    bar_prob: barycenter_problem.FreeBarycenterProblem, x_init: ArrayLike,
     rng: jax.random.PRNGKeyArray
 ) -> FreeBarycenterState:
   """Jittable Wasserstein barycenter outer loop."""

--- a/src/ott/solvers/linear/implicit_differentiation.py
+++ b/src/ott/solvers/linear/implicit_differentiation.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott import utils
 from ott.math import unbalanced_functions as uf
@@ -44,18 +45,18 @@ class ImplicitDiff:
     precondition_fun: TODO(marcocuturi)
   """
 
-  solver_fun: Callable[[jnp.ndarray, jnp.ndarray],
-                       Tuple[jnp.ndarray, ...]] = jax.scipy.sparse.linalg.cg
+  solver_fun: Callable[[ArrayLike, ArrayLike],
+                       Tuple[ArrayLike, ...]] = jax.scipy.sparse.linalg.cg
   ridge_kernel: float = 0.0
   ridge_identity: float = 0.0
   symmetric: bool = False
-  precondition_fun: Optional[Callable[[jnp.ndarray], jnp.ndarray]] = None
+  precondition_fun: Optional[Callable[[ArrayLike], ArrayLike]] = None
 
   def solve(
-      self, gr: Tuple[jnp.ndarray,
-                      jnp.ndarray], ot_prob: "linear_problem.LinearProblem",
-      f: jnp.ndarray, g: jnp.ndarray, lse_mode: bool
-  ) -> jnp.ndarray:
+      self, gr: Tuple[ArrayLike,
+                      ArrayLike], ot_prob: "linear_problem.LinearProblem",
+      f: ArrayLike, g: ArrayLike, lse_mode: bool
+  ) -> Array:
     r"""Apply minus inverse of [hessian ``reg_ot_cost`` w.r.t. ``f``, ``g``].
 
     This function is used to carry out implicit differentiation of ``sinkhorn``
@@ -229,8 +230,8 @@ class ImplicitDiff:
     return jnp.concatenate((-vjp_gr_f, -vjp_gr_g))
 
   def first_order_conditions(
-      self, prob, f: jnp.ndarray, g: jnp.ndarray, lse_mode: bool
-  ):
+      self, prob, f: ArrayLike, g: ArrayLike, lse_mode: bool
+  ) -> Array:
     r"""Compute vector of first order conditions for the reg-OT problem.
 
     The output of this vector should be close to zero at optimality.
@@ -271,8 +272,8 @@ class ImplicitDiff:
     return jnp.concatenate((result_a, result_b))
 
   def gradient(
-      self, prob: "linear_problem.LinearProblem", f: jnp.ndarray,
-      g: jnp.ndarray, lse_mode: bool, gr: Tuple[jnp.ndarray, jnp.ndarray]
+      self, prob: "linear_problem.LinearProblem", f: ArrayLike, g: ArrayLike,
+      lse_mode: bool, gr: Tuple[ArrayLike, ArrayLike]
   ) -> "linear_problem.LinearProblem":
     """Apply VJP to recover gradient in reverse mode differentiation."""
     # Applies first part of vjp to gr: inverse part of implicit function theorem

--- a/src/ott/solvers/nn/conjugate_solvers.py
+++ b/src/ott/solvers/nn/conjugate_solvers.py
@@ -14,7 +14,7 @@
 import abc
 from typing import Callable, Literal, NamedTuple, Optional
 
-import jax.numpy as jnp
+from jax.typing import ArrayLike
 from jaxopt import LBFGS
 
 from ott import utils
@@ -36,7 +36,7 @@ class ConjugateResults(NamedTuple):
     num_iter: the number of iterations taken by the solver
   """
   val: float
-  grad: jnp.ndarray
+  grad: ArrayLike
   num_iter: int
 
 
@@ -50,9 +50,9 @@ class FenchelConjugateSolver(abc.ABC):
   @abc.abstractmethod
   def solve(
       self,
-      f: Callable[[jnp.ndarray], jnp.ndarray],
-      y: jnp.ndarray,
-      x_init: Optional[jnp.ndarray] = None
+      f: Callable[[ArrayLike], ArrayLike],
+      y: ArrayLike,
+      x_init: Optional[ArrayLike] = None
   ) -> ConjugateResults:
     """Solve for the conjugate.
 
@@ -88,9 +88,9 @@ class FenchelConjugateLBFGS(FenchelConjugateSolver):
 
   def solve(  # noqa: D102
       self,
-      f: Callable[[jnp.ndarray], jnp.ndarray],
-      y: jnp.ndarray,
-      x_init: Optional[jnp.array] = None
+      f: Callable[[ArrayLike], ArrayLike],
+      y: ArrayLike,
+      x_init: Optional[ArrayLike] = None
   ) -> ConjugateResults:
     assert y.ndim == 1, y.ndim
 

--- a/src/ott/solvers/nn/layers.py
+++ b/src/ott/solvers/nn/layers.py
@@ -11,18 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+from jax._src.typing import DTypeLike, Shape
+from jax.typing import Array, ArrayLike
 
 __all__ = ["PositiveDense", "PosDefPotentials"]
-
-PRNGKey = Any
-Shape = Tuple[int]
-Dtype = Any
-Array = Any
 
 
 class PositiveDense(nn.Module):
@@ -40,18 +37,19 @@ class PositiveDense(nn.Module):
     bias_init: initializer function for the bias.
   """
   dim_hidden: int
-  rectifier_fn: Callable[[jnp.ndarray], jnp.ndarray] = nn.softplus
-  inv_rectifier_fn: Callable[[jnp.ndarray],
-                             jnp.ndarray] = lambda x: jnp.log(jnp.exp(x) - 1)
+  rectifier_fn: Callable[[ArrayLike], ArrayLike] = nn.softplus
+  inv_rectifier_fn: Callable[[ArrayLike],
+                             ArrayLike] = lambda x: jnp.log(jnp.exp(x) - 1)
   use_bias: bool = True
   dtype: Any = jnp.float32
   precision: Any = None
-  kernel_init: Callable[[PRNGKey, Shape, Dtype],
-                        Array] = nn.initializers.lecun_normal()
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = nn.initializers.zeros
+  kernel_init: Callable[[jax.random.PRNGKeyArray, Shape, DTypeLike],
+                        ArrayLike] = nn.initializers.lecun_normal()
+  bias_init: Callable[[jax.random.PRNGKeyArray, Shape, DTypeLike],
+                      ArrayLike] = nn.initializers.zeros
 
   @nn.compact
-  def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
+  def __call__(self, inputs: ArrayLike) -> Array:
     """Applies a linear transformation to inputs along the last dimension.
 
     Args:
@@ -93,12 +91,13 @@ class PosDefPotentials(nn.Module):
   use_bias: bool = True
   dtype: Any = jnp.float32
   precision: Any = None
-  kernel_init: Callable[[PRNGKey, Shape, Dtype],
-                        Array] = nn.initializers.lecun_normal()
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = nn.initializers.zeros
+  kernel_init: Callable[[jax.random.PRNGKeyArray, Shape, DTypeLike],
+                        ArrayLike] = nn.initializers.lecun_normal()
+  bias_init: Callable[[jax.random.PRNGKeyArray, Shape, DTypeLike],
+                      ArrayLike] = nn.initializers.zeros
 
   @nn.compact
-  def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
+  def __call__(self, inputs: ArrayLike) -> Array:
     """Apply a few quadratic forms.
 
     Args:

--- a/src/ott/solvers/nn/neuraldual.py
+++ b/src/ott/solvers/nn/neuraldual.py
@@ -27,6 +27,7 @@ import jax
 import jax.numpy as jnp
 import optax
 from flax import core
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import costs
 from ott.problems.linear import potentials
@@ -122,7 +123,7 @@ class W2NeuralDual:
       conjugate_solver: Conj_t = conjugate_solvers.DEFAULT_CONJUGATE_SOLVER,
       amortization_loss: Literal["objective", "regression"] = "regression",
       parallel_updates: bool = True,
-  ):
+  ) -> None:
     self.num_train_iters = num_train_iters
     self.num_inner_iters = num_inner_iters
     self.back_and_forth = back_and_forth
@@ -231,10 +232,10 @@ class W2NeuralDual:
 
   def __call__(  # noqa: D102
       self,
-      trainloader_source: Iterator[jnp.ndarray],
-      trainloader_target: Iterator[jnp.ndarray],
-      validloader_source: Iterator[jnp.ndarray],
-      validloader_target: Iterator[jnp.ndarray],
+      trainloader_source: Iterator[ArrayLike],
+      trainloader_target: Iterator[ArrayLike],
+      validloader_source: Iterator[ArrayLike],
+      validloader_target: Iterator[ArrayLike],
       callback: Optional[Callback_t] = None,
   ) -> Union[potentials.DualPotentials, Tuple[potentials.DualPotentials,
                                               Train_t]]:
@@ -251,10 +252,10 @@ class W2NeuralDual:
 
   def train_neuraldual_parallel(
       self,
-      trainloader_source: Iterator[jnp.ndarray],
-      trainloader_target: Iterator[jnp.ndarray],
-      validloader_source: Iterator[jnp.ndarray],
-      validloader_target: Iterator[jnp.ndarray],
+      trainloader_source: Iterator[ArrayLike],
+      trainloader_target: Iterator[ArrayLike],
+      validloader_source: Iterator[ArrayLike],
+      validloader_target: Iterator[ArrayLike],
       callback: Optional[Callback_t] = None,
   ) -> Train_t:
     """Training and validation with parallel updates."""
@@ -326,10 +327,10 @@ class W2NeuralDual:
 
   def train_neuraldual_alternating(
       self,
-      trainloader_source: Iterator[jnp.ndarray],
-      trainloader_target: Iterator[jnp.ndarray],
-      validloader_source: Iterator[jnp.ndarray],
-      validloader_target: Iterator[jnp.ndarray],
+      trainloader_source: Iterator[ArrayLike],
+      trainloader_target: Iterator[ArrayLike],
+      validloader_source: Iterator[ArrayLike],
+      validloader_target: Iterator[ArrayLike],
       callback: Optional[Callback_t] = None,
   ) -> Train_t:
     """Training and validation with alternating updates."""
@@ -406,7 +407,7 @@ class W2NeuralDual:
 
       init_source_hat = g_gradient(params_g)(target)
 
-      def g_value_partial(y: jnp.ndarray) -> jnp.ndarray:
+      def g_value_partial(y: ArrayLike) -> Array:
         """Lazy way of evaluating g if f's computation needs it."""
         return g_value(params_g)(y)
 
@@ -559,7 +560,7 @@ class W2NeuralDual:
     return core.freeze(params)
 
   @staticmethod
-  def _penalize_weights_icnn(params: Dict[str, jnp.ndarray]) -> float:
+  def _penalize_weights_icnn(params: Dict[str, ArrayLike]) -> float:
     penalty = 0.0
     for k, param in params.items():
       if k.startswith("w_z"):
@@ -569,9 +570,9 @@ class W2NeuralDual:
   @staticmethod
   def _update_logs(
       logs: Dict[str, List[Union[float, str]]],
-      loss_f: jnp.ndarray,
-      loss_g: jnp.ndarray,
-      w_dist: jnp.ndarray,
+      loss_f: ArrayLike,
+      loss_g: ArrayLike,
+      w_dist: ArrayLike,
   ) -> None:
     logs["loss_f"].append(float(loss_f))
     logs["loss_g"].append(float(loss_g))

--- a/src/ott/solvers/quadratic/gromov_wasserstein.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein.py
@@ -25,6 +25,7 @@ from typing import (
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import geometry, low_rank, pointcloud
 from ott.initializers.linear import initializers_lr
@@ -57,10 +58,10 @@ class GWOutput(NamedTuple):
     old_transport_mass: Holds total mass of transport at previous iteration.
   """
 
-  costs: Optional[jnp.ndarray] = None
-  linear_convergence: Optional[jnp.ndarray] = None
+  costs: Optional[ArrayLike] = None
+  linear_convergence: Optional[ArrayLike] = None
   converged: bool = False
-  errors: Optional[jnp.ndarray] = None
+  errors: Optional[ArrayLike] = None
   linear_state: Optional[LinearOutput] = None
   geom: Optional[geometry.Geometry] = None
   # Intermediate values.
@@ -71,11 +72,11 @@ class GWOutput(NamedTuple):
     return self._replace(**kwargs)
 
   @property
-  def matrix(self) -> jnp.ndarray:
+  def matrix(self) -> Array:
     """Transport matrix."""
     return self._rescale_factor * self.linear_state.matrix
 
-  def apply(self, inputs: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
+  def apply(self, inputs: ArrayLike, axis: int = 0) -> Array:
     """Apply the transport to an array; axis=1 for its transpose."""
     return self._rescale_factor * self.linear_state.apply(inputs, axis=axis)
 
@@ -112,13 +113,13 @@ class GWState(NamedTuple):
       at each iteration.
   """
 
-  costs: jnp.ndarray
-  linear_convergence: jnp.ndarray
+  costs: ArrayLike
+  linear_convergence: ArrayLike
   linear_state: LinearOutput
   linear_pb: linear_problem.LinearProblem
   old_transport_mass: float
   rngs: Optional[jax.random.PRNGKeyArray] = None
-  errors: Optional[jnp.ndarray] = None
+  errors: Optional[ArrayLike] = None
 
   def set(self, **kwargs: Any) -> "GWState":
     """Return a copy of self, possibly with overwrites."""
@@ -181,7 +182,7 @@ class GromovWasserstein(was_solver.WassersteinSolver):
                 quad_initializers.BaseQuadraticInitializer]] = None,
       kwargs_init: Optional[Mapping[str, Any]] = None,
       **kwargs: Any
-  ):
+  ) -> None:
     super().__init__(*args, **kwargs)
     self._warm_start = warm_start
     self.quad_initializer = quad_initializer
@@ -398,8 +399,8 @@ def solve(
     geom_xy: Optional[geometry.Geometry] = None,
     fused_penalty: float = 1.0,
     scale_cost: Optional[Union[bool, float, str]] = False,
-    a: Optional[jnp.ndarray] = None,
-    b: Optional[jnp.ndarray] = None,
+    a: Optional[ArrayLike] = None,
+    b: Optional[ArrayLike] = None,
     loss: Union[Literal["sqeucl", "kl"], quadratic_costs.GWLoss] = "sqeucl",
     tau_a: Optional[float] = 1.0,
     tau_b: Optional[float] = 1.0,

--- a/src/ott/solvers/quadratic/gw_barycenter.py
+++ b/src/ott/solvers/quadratic/gw_barycenter.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import pointcloud
 from ott.math import fixed_point_loop
@@ -42,12 +43,12 @@ class GWBarycenterState(NamedTuple):
     gw_convergence: Array of shape ``[max_iter,]`` containing the convergence
       of all GW problems at each iteration.
   """
-  cost: Optional[jnp.ndarray] = None
-  x: Optional[jnp.ndarray] = None
-  a: Optional[jnp.ndarray] = None
-  errors: Optional[jnp.ndarray] = None
-  costs: Optional[jnp.ndarray] = None
-  gw_convergence: Optional[jnp.ndarray] = None
+  cost: Optional[ArrayLike] = None
+  x: Optional[ArrayLike] = None
+  a: Optional[ArrayLike] = None
+  errors: Optional[ArrayLike] = None
+  costs: Optional[ArrayLike] = None
+  gw_convergence: Optional[ArrayLike] = None
 
   def set(self, **kwargs: Any) -> "GWBarycenterState":
     """Return a copy of self, possibly with overwrites."""
@@ -86,7 +87,7 @@ class GromovWassersteinBarycenter(was_solver.WassersteinSolver):
       # will be fixed when refactoring the solvers
       # note that `was_solver` also suffers from this
       **kwargs: Any,
-  ):
+  ) -> None:
     super().__init__(
         epsilon=epsilon,
         min_iterations=min_iterations,
@@ -126,9 +127,8 @@ class GromovWassersteinBarycenter(was_solver.WassersteinSolver):
       self,
       problem: gw_barycenter.GWBarycenterProblem,
       bar_size: int,
-      bar_init: Optional[Union[jnp.ndarray, Tuple[jnp.ndarray,
-                                                  jnp.ndarray]]] = None,
-      a: Optional[jnp.ndarray] = None,
+      bar_init: Optional[Union[ArrayLike, Tuple[ArrayLike, ArrayLike]]] = None,
+      a: Optional[ArrayLike] = None,
       rng: jax.random.PRNGKeyArray = jax.random.PRNGKey(0),
   ) -> GWBarycenterState:
     """Initialize the (fused) Gromov-Wasserstein barycenter state.
@@ -200,13 +200,13 @@ class GromovWassersteinBarycenter(was_solver.WassersteinSolver):
       iteration: int,
       problem: gw_barycenter.GWBarycenterProblem,
       store_errors: bool = True,
-  ) -> Tuple[float, bool, jnp.ndarray, Optional[jnp.ndarray]]:
+  ) -> Tuple[float, bool, ArrayLike, Optional[ArrayLike]]:
     """Solve the (fused) Gromov-Wasserstein barycenter problem."""
 
     def solve_gw(
-        state: GWBarycenterState, b: jnp.ndarray, y: jnp.ndarray,
-        f: Optional[jnp.ndarray]
-    ) -> Tuple[float, bool, jnp.ndarray, Optional[jnp.ndarray]]:
+        state: GWBarycenterState, b: ArrayLike, y: ArrayLike,
+        f: Optional[ArrayLike]
+    ) -> Tuple[float, bool, Array, Optional[Array]]:
       quad_problem = problem._create_problem(state, y=y, b=b, f=f)
       out = self._quad_solver(quad_problem)
       return (
@@ -269,9 +269,9 @@ class GromovWassersteinBarycenter(was_solver.WassersteinSolver):
 
 @partial(jax.vmap, in_axes=[None, 0, None, 0, None])
 def init_transports(
-    solver, rng: jax.random.PRNGKeyArray, a: jnp.ndarray, b: jnp.ndarray,
+    solver, rng: jax.random.PRNGKeyArray, a: ArrayLike, b: ArrayLike,
     epsilon: Optional[float]
-) -> jnp.ndarray:
+) -> Array:
   """Initialize random 2D point cloud and solve the linear OT problem.
 
   Args:

--- a/src/ott/solvers/was_solver.py
+++ b/src/ott/solvers/was_solver.py
@@ -42,7 +42,7 @@ class WassersteinSolver:
       jit: bool = True,
       store_inner_errors: bool = False,
       **kwargs: Any,
-  ):
+  ) -> None:
     from ott.solvers.linear import sinkhorn, sinkhorn_lr
     default_epsilon = 1.0
     # Set epsilon value to default if needed, but keep track of whether None was

--- a/src/ott/tools/gaussian_mixture/fit_gmm.py
+++ b/src/ott/tools/gaussian_mixture/fit_gmm.py
@@ -53,6 +53,7 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.tools.gaussian_mixture import gaussian_mixture
 
@@ -62,8 +63,8 @@ __all__ = ["initialize", "fit_model_em"]
 
 
 def get_assignment_probs(
-    gmm: gaussian_mixture.GaussianMixture, points: jnp.ndarray
-) -> jnp.ndarray:
+    gmm: gaussian_mixture.GaussianMixture, points: ArrayLike
+) -> Array:
   r"""Get component assignment probabilities used in the E step of EM.
 
   Here we compute the component assignment probabilities p(Z|X, \Theta^{(t)})
@@ -81,9 +82,9 @@ def get_assignment_probs(
 
 def get_q(
     gmm: gaussian_mixture.GaussianMixture,
-    assignment_probs: jnp.ndarray,
-    points: jnp.ndarray,
-    point_weights: Optional[jnp.ndarray] = None,
+    assignment_probs: ArrayLike,
+    points: ArrayLike,
+    point_weights: Optional[ArrayLike] = None,
 ) -> float:
   r"""Get Q(\Theta|\Theta^{(t)}).
 
@@ -109,8 +110,8 @@ def get_q(
 
 def log_prob_loss(
     gmm: gaussian_mixture.GaussianMixture,
-    points: jnp.ndarray,
-    point_weights: Optional[jnp.ndarray] = None,
+    points: ArrayLike,
+    point_weights: Optional[ArrayLike] = None,
 ) -> float:
   """Loss function: weighted mean of (-log prob of observations).
 
@@ -130,8 +131,8 @@ def log_prob_loss(
 
 def fit_model_em(
     gmm: gaussian_mixture.GaussianMixture,
-    points: jnp.ndarray,
-    point_weights: Optional[jnp.ndarray],
+    points: ArrayLike,
+    point_weights: Optional[ArrayLike],
     steps: int,
     jit: bool = True,
     verbose: bool = False,
@@ -184,10 +185,10 @@ def fit_model_em(
 # See https://en.wikipedia.org/wiki/K-means%2B%2B for details
 
 
-def _get_dist_sq(points: jnp.ndarray, loc: jnp.ndarray) -> jnp.ndarray:
+def _get_dist_sq(points: ArrayLike, loc: ArrayLike) -> Array:
   """Get the squared distance from each point to each loc."""
 
-  def _dist_sq_one_loc(points: jnp.ndarray, loc: jnp.ndarray) -> jnp.ndarray:
+  def _dist_sq_one_loc(points: ArrayLike, loc: ArrayLike) -> Array:
     return jnp.sum((points - loc[None]) ** 2., axis=-1)
 
   dist_sq_fn = jax.vmap(_dist_sq_one_loc, in_axes=(None, 0), out_axes=1)
@@ -195,8 +196,8 @@ def _get_dist_sq(points: jnp.ndarray, loc: jnp.ndarray) -> jnp.ndarray:
 
 
 def _get_locs(
-    rng: jax.random.PRNGKeyArray, points: jnp.ndarray, n_components: int
-) -> jnp.ndarray:
+    rng: jax.random.PRNGKeyArray, points: ArrayLike, n_components: int
+) -> Array:
   """Get the initial component means.
 
   Args:
@@ -230,8 +231,8 @@ def _get_locs(
 
 def from_kmeans_plusplus(
     rng: jax.random.PRNGKeyArray,
-    points: jnp.ndarray,
-    point_weights: Optional[jnp.ndarray],
+    points: ArrayLike,
+    point_weights: Optional[ArrayLike],
     n_components: int,
 ) -> gaussian_mixture.GaussianMixture:
   """Initialize a GMM via a single pass of K-means++.
@@ -266,8 +267,8 @@ def from_kmeans_plusplus(
 
 def initialize(
     rng: jax.random.PRNGKeyArray,
-    points: jnp.ndarray,
-    point_weights: Optional[jnp.ndarray],
+    points: ArrayLike,
+    point_weights: Optional[ArrayLike],
     n_components: int,
     n_attempts: int = 50,
     verbose: bool = False

--- a/src/ott/tools/gaussian_mixture/gaussian_mixture_pair.py
+++ b/src/ott/tools/gaussian_mixture/gaussian_mixture_pair.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+from jax._src.typing import DTypeLike
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import costs, geometry, pointcloud
 from ott.problems.linear import linear_problem
@@ -54,7 +56,7 @@ class GaussianMixturePair:
       epsilon: float = 1.e-2,
       tau: float = 1.,
       lock_gmm1: bool = False,
-  ):
+  ) -> None:
     """Constructor.
 
     When fitting a pair of coupled GMMs with *no* reweighting of components
@@ -83,31 +85,31 @@ class GaussianMixturePair:
     self._lock_gmm1 = lock_gmm1
 
   @property
-  def dtype(self):  # noqa: D102
+  def dtype(self) -> DTypeLike:  # noqa: D102
     return self.gmm0.dtype
 
   @property
-  def gmm0(self):  # noqa: D102
+  def gmm0(self) -> gaussian_mixture.GaussianMixture:  # noqa: D102
     return self._gmm0
 
   @property
-  def gmm1(self):  # noqa: D102
+  def gmm1(self) -> gaussian_mixture.GaussianMixture:  # noqa: D102
     return self._gmm1
 
   @property
-  def epsilon(self):  # noqa: D102
+  def epsilon(self) -> float:  # noqa: D102
     return self._epsilon
 
   @property
-  def tau(self):  # noqa: D102
+  def tau(self) -> float:  # noqa: D102
     return self._tau
 
   @property
-  def rho(self):  # noqa: D102
+  def rho(self) -> float:  # noqa: D102
     return self.epsilon * self.tau / (1. - self.tau)
 
   @property
-  def lock_gmm1(self):  # noqa: D102
+  def lock_gmm1(self) -> bool:  # noqa: D102
     return self._lock_gmm1
 
   def get_bures_geometry(self) -> pointcloud.PointCloud:
@@ -128,12 +130,12 @@ class GaussianMixturePair:
         epsilon=self.epsilon
     )
 
-  def get_cost_matrix(self) -> jnp.ndarray:
+  def get_cost_matrix(self) -> Array:
     """Get matrix of :math:`W_2^2` costs between all pairs of components."""
     return self.get_bures_geometry().cost_matrix
 
   def get_sinkhorn(
-      self, cost_matrix: jnp.ndarray, **kwargs: Any
+      self, cost_matrix: ArrayLike, **kwargs: Any
   ) -> sinkhorn.SinkhornOutput:
     """Get the output of Sinkhorn's method for a given cost matrix."""
     # We use a Geometry here rather than the PointCloud created in
@@ -152,7 +154,7 @@ class GaussianMixturePair:
   def get_normalized_sinkhorn_coupling(
       self,
       sinkhorn_output: sinkhorn.SinkhornOutput,
-  ) -> jnp.ndarray:
+  ) -> Array:
     """Get the normalized coupling matrix for the specified Sinkhorn output.
 
     Args:
@@ -207,7 +209,7 @@ class GaussianMixturePair:
       children.insert(1, gmm1)
     return cls(*children, **aux_data)
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     class_name = type(self).__name__
     children, aux = self.tree_flatten()
     return "{}({})".format(
@@ -215,8 +217,8 @@ class GaussianMixturePair:
                               [f"{k}: {repr(v)}" for k, v in aux.items()])
     )
 
-  def __hash__(self):
+  def __hash__(self) -> int:
     return jax.tree_util.tree_flatten(self).__hash__()
 
-  def __eq__(self, other):
+  def __eq__(self, other) -> bool:
     return jax.tree_util.tree_flatten(self) == jax.tree_util.tree_flatten(other)

--- a/src/ott/tools/gaussian_mixture/linalg.py
+++ b/src/ott/tools/gaussian_mixture/linalg.py
@@ -15,12 +15,14 @@ from typing import Callable, Iterable, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax._src.typing import DTypeLike
+from jax.typing import Array, ArrayLike
 
 
 def get_mean_and_var(
-    points: jnp.ndarray,  # (n, d)
-    weights: jnp.ndarray,  # (n,)
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    points: ArrayLike,  # (n, d)
+    weights: ArrayLike,  # (n,)
+) -> Tuple[Array, Array]:
   """Get the mean and variance of a weighted set of points."""
   weights_sum = jnp.sum(weights, axis=-1)  # (1,)
   mean = (
@@ -37,9 +39,9 @@ def get_mean_and_var(
 
 
 def get_mean_and_cov(
-    points: jnp.ndarray,  # (n, d)
-    weights: jnp.ndarray,  # (n,)
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    points: ArrayLike,  # (n, d)
+    weights: ArrayLike,  # (n,)
+) -> Tuple[Array, Array]:
   """Get the mean and covariance of a weighted set of points."""
   weights_sum = jnp.sum(weights, axis=-1, keepdims=True)  # (1,)
   mean = (
@@ -59,7 +61,7 @@ def get_mean_and_cov(
   return mean, cov
 
 
-def flat_to_tril(x: jnp.ndarray, size: int) -> jnp.ndarray:
+def flat_to_tril(x: ArrayLike, size: int) -> Array:
   """Map flat values to lower triangular matrices.
 
   Args:
@@ -76,7 +78,7 @@ def flat_to_tril(x: jnp.ndarray, size: int) -> jnp.ndarray:
   return m.at[..., tril[0], tril[1]].set(x)
 
 
-def tril_to_flat(m: jnp.ndarray) -> jnp.ndarray:
+def tril_to_flat(m: ArrayLike) -> Array:
   """Flatten lower triangular matrices.
 
   Args:
@@ -90,9 +92,7 @@ def tril_to_flat(m: jnp.ndarray) -> jnp.ndarray:
   return m[..., tril[0], tril[1]]
 
 
-def apply_to_diag(
-    m: jnp.ndarray, fn: Callable[[jnp.ndarray], jnp.ndarray]
-) -> jnp.ndarray:
+def apply_to_diag(m: ArrayLike, fn: Callable[[ArrayLike], ArrayLike]) -> Array:
   """Apply a function to the diagonal of a matrix."""
   size = m.shape[-1]
   diag = jnp.diagonal(m, axis1=-2, axis2=-1)
@@ -101,9 +101,9 @@ def apply_to_diag(
 
 
 def matrix_powers(
-    m: jnp.ndarray,
+    m: ArrayLike,
     powers: Iterable[float],
-) -> List[jnp.ndarray]:
+) -> List[Array]:
   """Raise a real, symmetric matrix to multiple powers."""
   eigs, q = jnp.linalg.eigh(m)
   qt = jnp.swapaxes(q, axis1=-2, axis2=-1)
@@ -113,9 +113,7 @@ def matrix_powers(
   return ret
 
 
-def invmatvectril(
-    m: jnp.ndarray, x: jnp.ndarray, lower: bool = True
-) -> jnp.ndarray:
+def invmatvectril(m: ArrayLike, x: ArrayLike, lower: bool = True) -> Array:
   """Multiply x by the inverse of a triangular matrix.
 
   Args:
@@ -134,8 +132,8 @@ def invmatvectril(
 def get_random_orthogonal(
     rng: jax.random.PRNGKeyArray,
     dim: int,
-    dtype: Optional[jnp.dtype] = None
-) -> jnp.ndarray:
+    dtype: Optional[DTypeLike] = None
+) -> Array:
   """Get a random orthogonal matrix with the specified dimension."""
   m = jax.random.normal(key=rng, shape=[dim, dim], dtype=dtype)
   q, _ = jnp.linalg.qr(m)

--- a/src/ott/tools/plot.py
+++ b/src/ott/tools/plot.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 import jax.numpy as jnp
 import numpy as np
 import scipy
+from jax.typing import Array, ArrayLike
 
 from ott import utils
 from ott.geometry import pointcloud
@@ -33,8 +34,7 @@ Transport = Union[sinkhorn.SinkhornOutput, sinkhorn_lr.LRSinkhornOutput,
                   gromov_wasserstein.GWOutput]
 
 
-def bidimensional(x: jnp.ndarray,
-                  y: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+def bidimensional(x: ArrayLike, y: ArrayLike) -> Tuple[Array, Array]:
   """Apply PCA to reduce to bi-dimensional data."""
   if x.shape[1] < 3:
     return x, y
@@ -90,7 +90,7 @@ class Plot:
     self._scale_alpha_by_coupling = scale_alpha_by_coupling
     self._alpha = alpha
 
-  def _scatter(self, ot: Transport):
+  def _scatter(self, ot: Transport) -> Tuple[Array, Array, Array, Array]:
     """Compute the position and scales of the points on a 2D plot."""
     if not isinstance(ot.geom, pointcloud.PointCloud):
       raise ValueError("So far we only plot PointCloud geometry.")
@@ -102,7 +102,7 @@ class Plot:
     scales_y = b * self._scale * b.shape[0]
     return x, y, scales_x, scales_y
 
-  def _mapping(self, x: jnp.ndarray, y: jnp.ndarray, matrix: jnp.ndarray):
+  def _mapping(self, x: ArrayLike, y: ArrayLike, matrix: ArrayLike):
     """Compute the lines representing the mapping between the 2 point clouds."""
     # Only plot the lines with a cost above the threshold.
     u, v = jnp.where(matrix > self._threshold)
@@ -218,10 +218,10 @@ class Plot:
 
 def _barycenters(
     ax: "plt.Axes",
-    y: jnp.ndarray,
-    a: jnp.ndarray,
-    b: jnp.ndarray,
-    matrix: jnp.ndarray,
+    y: ArrayLike,
+    a: ArrayLike,
+    b: ArrayLike,
+    matrix: ArrayLike,
     scale: int = 200
 ) -> None:
   """Plot 2-D sinkhorn barycenters."""
@@ -233,13 +233,13 @@ def _barycenters(
 
 
 def barycentric_projections(
-    arg: Union[Transport, jnp.ndarray],
-    a: jnp.ndarray = None,
-    b: jnp.ndarray = None,
-    matrix: jnp.ndarray = None,
+    arg: Union[Transport, ArrayLike],
+    a: ArrayLike = None,
+    b: ArrayLike = None,
+    matrix: ArrayLike = None,
     ax: Optional["plt.Axes"] = None,
     **kwargs
-):
+) -> None:
   """Plot the barycenters, from the Transport object or from arguments."""
   if ax is None:
     _, ax = plt.subplots(1, 1, figsize=(8, 5))

--- a/src/ott/tools/segment_sinkhorn.py
+++ b/src/ott/tools/segment_sinkhorn.py
@@ -14,7 +14,7 @@
 from types import MappingProxyType
 from typing import Any, Mapping, Optional, Tuple
 
-import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import costs, pointcloud, segment
 from ott.problems.linear import linear_problem
@@ -22,21 +22,21 @@ from ott.solvers.linear import sinkhorn
 
 
 def segment_sinkhorn(
-    x: jnp.ndarray,
-    y: jnp.ndarray,
+    x: ArrayLike,
+    y: ArrayLike,
     num_segments: Optional[int] = None,
     max_measure_size: Optional[int] = None,
     cost_fn: Optional[costs.CostFn] = None,
-    segment_ids_x: Optional[jnp.ndarray] = None,
-    segment_ids_y: Optional[jnp.ndarray] = None,
+    segment_ids_x: Optional[ArrayLike] = None,
+    segment_ids_y: Optional[ArrayLike] = None,
     indices_are_sorted: bool = False,
     num_per_segment_x: Optional[Tuple[int, ...]] = None,
     num_per_segment_y: Optional[Tuple[int, ...]] = None,
-    weights_x: Optional[jnp.ndarray] = None,
-    weights_y: Optional[jnp.ndarray] = None,
+    weights_x: Optional[ArrayLike] = None,
+    weights_y: Optional[ArrayLike] = None,
     sinkhorn_kwargs: Mapping[str, Any] = MappingProxyType({}),
     **kwargs: Any
-) -> jnp.ndarray:
+) -> Array:
   """Compute regularized OT cost between subsets of vectors in `x` and `y`.
 
   Helper function designed to compute Sinkhorn regularized OT cost between
@@ -104,10 +104,10 @@ def segment_sinkhorn(
     padding_vector = cost_fn._padder(dim=dim)
 
   def eval_fn(
-      padded_x: jnp.ndarray,
-      padded_y: jnp.ndarray,
-      padded_weight_x: jnp.ndarray,
-      padded_weight_y: jnp.ndarray,
+      padded_x: ArrayLike,
+      padded_y: ArrayLike,
+      padded_weight_x: ArrayLike,
+      padded_weight_y: ArrayLike,
   ) -> float:
     mask_x = padded_weight_x > 0.
     mask_y = padded_weight_y > 0.

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -15,6 +15,7 @@ from types import MappingProxyType
 from typing import Any, List, Mapping, NamedTuple, Optional, Tuple, Type
 
 import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 from ott.geometry import costs, geometry, pointcloud, segment
 from ott.problems.linear import linear_problem, potentials
@@ -28,13 +29,12 @@ __all__ = [
 
 class SinkhornDivergenceOutput(NamedTuple):  # noqa: D101
   divergence: float
-  potentials: Tuple[List[jnp.ndarray], List[jnp.ndarray], List[jnp.ndarray]]
+  potentials: Tuple[List[ArrayLike], List[ArrayLike], List[ArrayLike]]
   geoms: Tuple[geometry.Geometry, geometry.Geometry, geometry.Geometry]
-  errors: Tuple[Optional[jnp.ndarray], Optional[jnp.ndarray],
-                Optional[jnp.ndarray]]
+  errors: Tuple[Optional[ArrayLike], Optional[ArrayLike], Optional[ArrayLike]]
   converged: Tuple[bool, bool, bool]
-  a: jnp.ndarray
-  b: jnp.ndarray
+  a: ArrayLike
+  b: ArrayLike
 
   def to_dual_potentials(self) -> "potentials.EntropicPotentials":
     """Return dual estimators :cite:`pooladian:22`, eq. 8."""
@@ -49,8 +49,8 @@ class SinkhornDivergenceOutput(NamedTuple):  # noqa: D101
 def sinkhorn_divergence(
     geom: Type[geometry.Geometry],
     *args: Any,
-    a: Optional[jnp.ndarray] = None,
-    b: Optional[jnp.ndarray] = None,
+    a: Optional[ArrayLike] = None,
+    b: Optional[ArrayLike] = None,
     sinkhorn_kwargs: Mapping[str, Any] = MappingProxyType({}),
     static_b: bool = False,
     share_epsilon: bool = True,
@@ -114,8 +114,8 @@ def _sinkhorn_divergence(
     geometry_xy: geometry.Geometry,
     geometry_xx: geometry.Geometry,
     geometry_yy: Optional[geometry.Geometry],
-    a: jnp.ndarray,
-    b: jnp.ndarray,
+    a: ArrayLike,
+    b: ArrayLike,
     symmetric_sinkhorn: bool,
     **kwargs: Any,
 ) -> SinkhornDivergenceOutput:
@@ -131,9 +131,9 @@ def _sinkhorn_divergence(
     between elements of the view X.
     geometry_yy: a Cost object able to apply kernels with a certain epsilon,
     between elements of the view Y.
-    a: jnp.ndarray<float>[n]: the weight of each input point. The sum of
+    a: ArrayLike<float>[n]: the weight of each input point. The sum of
      all elements of ``b`` must match that of ``a`` to converge.
-    b: jnp.ndarray<float>[m]: the weight of each target point. The sum of
+    b: ArrayLike<float>[m]: the weight of each target point. The sum of
      all elements of ``b`` must match that of ``a`` to converge.
     symmetric_sinkhorn: Use Sinkhorn updates in Eq. 25 of :cite:`feydy:19` for
       symmetric terms comparing x/x and y/y.
@@ -183,24 +183,24 @@ def _sinkhorn_divergence(
 
 
 def segment_sinkhorn_divergence(
-    x: jnp.ndarray,
-    y: jnp.ndarray,
+    x: ArrayLike,
+    y: ArrayLike,
     num_segments: Optional[int] = None,
     max_measure_size: Optional[int] = None,
     cost_fn: Optional[costs.CostFn] = None,
-    segment_ids_x: Optional[jnp.ndarray] = None,
-    segment_ids_y: Optional[jnp.ndarray] = None,
+    segment_ids_x: Optional[ArrayLike] = None,
+    segment_ids_y: Optional[ArrayLike] = None,
     indices_are_sorted: bool = False,
     num_per_segment_x: Optional[Tuple[int, ...]] = None,
     num_per_segment_y: Optional[Tuple[int, ...]] = None,
-    weights_x: Optional[jnp.ndarray] = None,
-    weights_y: Optional[jnp.ndarray] = None,
+    weights_x: Optional[ArrayLike] = None,
+    weights_y: Optional[ArrayLike] = None,
     sinkhorn_kwargs: Mapping[str, Any] = MappingProxyType({}),
     static_b: bool = False,
     share_epsilon: bool = True,
     symmetric_sinkhorn: bool = False,
     **kwargs: Any
-) -> jnp.ndarray:
+) -> Array:
   """Compute Sinkhorn divergence between subsets of vectors in `x` and `y`.
 
   Helper function designed to compute Sinkhorn divergences between several point
@@ -219,9 +219,9 @@ def segment_sinkhorn_divergence(
   a tensor, and `vmap` used to evaluate Sinkhorn divergences in parallel.
 
   Args:
-    x: Array of input points, of shape `[num_x, feature]`.
+    x: ArrayLike of input points, of shape `[num_x, feature]`.
       Multiple segments are held in this single array.
-    y: Array of target points, of shape `[num_y, feature]`.
+    y: ArrayLike of target points, of shape `[num_y, feature]`.
     num_segments: Number of segments contained in `x` and `y`.
       Providing this is required for JIT compilation to work,
       see also :func:`~ott.geometry.segment.segment_point_cloud`.

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -219,9 +219,9 @@ def segment_sinkhorn_divergence(
   a tensor, and `vmap` used to evaluate Sinkhorn divergences in parallel.
 
   Args:
-    x: ArrayLike of input points, of shape `[num_x, feature]`.
+    x: Array of input points, of shape `[num_x, feature]`.
       Multiple segments are held in this single array.
-    y: ArrayLike of target points, of shape `[num_y, feature]`.
+    y: Array of target points, of shape `[num_y, feature]`.
     num_segments: Number of segments contained in `x` and `y`.
       Providing this is required for JIT compilation to work,
       see also :func:`~ott.geometry.segment.segment_point_cloud`.

--- a/src/ott/types.py
+++ b/src/ott/types.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Protocol
 
-import jax.numpy as jnp
+from jax.typing import Array, ArrayLike
 
 __all__ = ["Transport"]
 
@@ -28,11 +28,11 @@ class Transport(Protocol):
   """
 
   @property
-  def matrix(self) -> jnp.ndarray:
+  def matrix(self) -> Array:
     ...
 
-  def apply(self, inputs: jnp.ndarray, axis: int) -> jnp.ndarray:
+  def apply(self, inputs: ArrayLike, axis: int) -> Array:
     ...
 
-  def marginal(self, axis: int = 0) -> jnp.ndarray:
+  def marginal(self, axis: int = 0) -> Array:
     ...


### PR DESCRIPTION
Aims to fix #251, Follows recommended best practice of using [ArrayLike](https://jax.readthedocs.io/en/latest/_autosummary/jax.typing.ArrayLike.html#jax.typing.ArrayLike) for array inputs, and [Array](https://jax.readthedocs.io/en/latest/_autosummary/jax.Array.html#jax.Array) for array outputs.