### PR TITLE
add dtype to kernel

### DIFF
--- a/src/ott/solvers/nn/layers.py
+++ b/src/ott/solvers/nn/layers.py
@@ -65,6 +65,7 @@ class PositiveDense(nn.Module):
         "kernel", self.kernel_init, (inputs.shape[-1], self.dim_hidden)
     )
     kernel = self.rectifier_fn(kernel)
+    kernel = jnp.asarray(kernel, self.dtype)
     y = jax.lax.dot_general(
         inputs,
         kernel, (((inputs.ndim - 1,), (0,)), ((), ())),


### PR DESCRIPTION
While the `dtype` of the bias is explicitly set, this is not the case for the `kernel`, potentially leading to errors. As discussed with @michalk8. 