### PR TITLE
Fine grained control of Bures barycenters

### DIFF
--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -612,7 +612,7 @@ class Bures(CostFn):
       xs: jnp.ndarray,
       tolerance: float = 1e-4,
       sqrtm_kw: Optional[Dict[str, Any]] = None,
-      **kwargs
+      **kwargs: Any
   ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute the Bures barycenter of weighted Gaussian distributions.
 

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -270,7 +270,8 @@ class SqEuclidean(TICost):
   def h_legendre(self, z: jnp.ndarray) -> float:  # noqa: D102
     return 0.25 * jnp.sum(z ** 2)
 
-  def barycenter(self, weights: jnp.ndarray, xs: jnp.ndarray) -> jnp.ndarray:
+  def barycenter(self, weights: jnp.ndarray,
+                 xs: jnp.ndarray) -> Tuple[jnp.ndarray, Any]:
     """Output barycenter of vectors when using squared-Euclidean distance."""
     return jnp.average(xs, weights=weights, axis=0), None
 
@@ -502,10 +503,10 @@ class Bures(CostFn):
       behavior of inner calls to :func:`~ott.math.matrix_square_root.sqrtm`.
   """
 
-  def __init__(self, dimension: int, sqrtm_kw: Dict[str, Any] = None):
+  def __init__(self, dimension: int, sqrtm_kw: Optional[Dict[str, Any]] = None):
     super().__init__()
     self._dimension = dimension
-    self._sqrtm_kw = sqrtm_kw if sqrtm_kw is not None else {}
+    self._sqrtm_kw = {} if sqrtm_kw is None else sqrtm_kw
 
   def norm(self, x: jnp.ndarray) -> jnp.ndarray:
     """Compute norm of Gaussian, sq. 2-norm of mean + trace of covariance."""
@@ -531,8 +532,8 @@ class Bures(CostFn):
       covs: jnp.ndarray,
       weights: jnp.ndarray,
       tolerance: float = 1e-4,
-      sqrtm_kw: Dict[Any, Any] = None,
-      **kwargs
+      sqrtm_kw: Optional[Dict[Any, Any]] = None,
+      **kwargs: Any
   ) -> jnp.ndarray:
     """Iterate fix-point updates to compute barycenter of Gaussians.
 
@@ -542,7 +543,7 @@ class Bures(CostFn):
       tolerance: tolerance of the fixed-point procedure. That tolerance is
         applied to the Frobenius norm (normalized by total size)
         of two successive iterations of the algorithm
-      sqrtm_kw: keyword arguments for :func:`ott.math.matrix_square_root.sqrtm`
+      sqrtm_kw: keyword arguments for :func:`~ott.math.matrix_square_root.sqrtm`
       kwargs: keyword arguments for the outer fixed-point iteration
 
     Returns:
@@ -609,9 +610,9 @@ class Bures(CostFn):
       weights: jnp.ndarray,
       xs: jnp.ndarray,
       tolerance: float = 1e-4,
-      sqrtm_kw: Dict[str, Any] = None,
+      sqrtm_kw: Optional[Dict[str, Any]] = None,
       **kwargs
-  ) -> jnp.ndarray:
+  ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute the Bures barycenter of weighted Gaussian distributions.
 
     Implements the fixed point approach proposed in :cite:`alvarez-esteban:16`

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -69,7 +69,8 @@ class CostFn(abc.ABC):
       The cost.
     """
 
-  def barycenter(self, weights: jnp.ndarray, xs: jnp.ndarray) -> jnp.ndarray:
+  def barycenter(self, weights: jnp.ndarray,
+                 xs: jnp.ndarray) -> Tuple[jnp.ndarray, Any]:
     """Barycentric operator.
 
     Args:

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -670,7 +670,7 @@ class Bures(CostFn):
   @classmethod
   def tree_unflatten(cls, aux_data, children):  # noqa: D102
     del children
-    return cls(aux_data[0], **aux_data[1])
+    return cls(*aux_data)
 
 
 @jax.tree_util.register_pytree_node_class

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -533,7 +533,7 @@ class Bures(CostFn):
       covs: jnp.ndarray,
       weights: jnp.ndarray,
       tolerance: float = 1e-4,
-      sqrtm_kw: Optional[Dict[Any, Any]] = None,
+      sqrtm_kw: Optional[Dict[str, Any]] = None,
       **kwargs: Any
   ) -> jnp.ndarray:
     """Iterate fix-point updates to compute barycenter of Gaussians.
@@ -628,7 +628,7 @@ class Bures(CostFn):
       tolerance: convergence tolerance to control the termination of the
         algorithm.
       sqrtm_kw: Arguments passed on to the
-        :func:`ott.math.matrix_square_root.sqrtm` function used within
+        :func:`~ott.math.matrix_square_root.sqrtm` function used within
         :meth:`covariance_fixpoint_iter`. This defines the precision
         (in terms of convergence threshold, and number of iterations) of the
         matrix square root calls that are used at each outer iteration of
@@ -637,7 +637,7 @@ class Bures(CostFn):
       kwargs: Passed on to :meth:`covariance_fixpoint_iter`, to specify the
         number of iterations and tolerance of the fixed-point iteration of the
         barycenter routine, by parameterizing `tolerance` and other relevant
-        arguments passed on to :meth:`ott.math.fixed_point_loop.fixpoint_iter`,
+        arguments passed on to :func:`~ott.math.fixed_point_loop.fixpoint_iter`,
         namely `min_iterations`, `max_iterations` and `inner_iterations`.
 
     Returns:

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -500,11 +500,9 @@ class Bures(CostFn):
     dimension: Dimensionality of the data.
     sqrtm_kw: Dictionary of keyword arguments to control the
       behavior of inner calls to :func:`~ott.math.matrix_square_root.sqrtm`.
-    kwargs: keyword arguments to control the behavior of the fixed-point
-      iterations used in the inner computation of barycenters of Gaussians.
   """
 
-  def __init__(self, dimension: int, sqrtm_kw: Dict[str, Any] = None, **kwargs):
+  def __init__(self, dimension: int, sqrtm_kw: Dict[str, Any] = None):
     super().__init__()
     self._dimension = dimension
     self._sqrtm_kw = sqrtm_kw if sqrtm_kw is not None else {}
@@ -548,9 +546,12 @@ class Bures(CostFn):
       kwargs: keyword arguments for the outer fixed-point iteration
 
     Returns:
-      Weighted Bures average of the covariance matrices.
+      List containing Weighted Bures average of the covariance matrices, and
+      vector of (normalized) 2-norms of successive differences between iterates,
+      to monitor convergence.
     """
     sqrtm_kw = {} if sqrtm_kw is None else sqrtm_kw
+    # Pop values or set defaults for fixed-point loop.
     min_iterations = kwargs.pop("min_iterations", 1)
     max_iterations = kwargs.pop("max_iterations", 100)
     inner_iterations = kwargs.pop("inner_iterations", 5)
@@ -608,7 +609,7 @@ class Bures(CostFn):
       weights: jnp.ndarray,
       xs: jnp.ndarray,
       tolerance: float = 1e-4,
-      sqrtm_kw: Dict[Any, Any] = None,
+      sqrtm_kw: Dict[str, Any] = None,
       **kwargs
   ) -> jnp.ndarray:
     """Compute the Bures barycenter of weighted Gaussian distributions.
@@ -628,9 +629,9 @@ class Bures(CostFn):
         :func:`ott.math.matrix_square_root.sqrtm` function used within
         :meth:`covariance_fixpoint_iter`. This defines the precision
         (in terms of convergence threshold, and number of iterations) of the
-        matrix square root call. That call is used at each outer iteration of
-        the computation of Gaussian barycenters. These values are by default, if
-        not passed, the same as those used to compute the Bures distance.
+        matrix square root calls that are used at each outer iteration of
+        the computation of Gaussian barycenters. These values are, by default,
+        the same as those used to define the Bures cost object itself.
       kwargs: Passed on to :meth:`covariance_fixpoint_iter`, to specify the
         number of iterations and tolerance of the fixed-point iteration of the
         barycenter routine, by parameterizing `tolerance` and other relevant

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -529,7 +529,7 @@ class PointCloud(geometry.Geometry):
 
   def barycenter(self, weights: jnp.ndarray) -> jnp.ndarray:
     """Compute barycenter of points in self.x using weights."""
-    return self.cost_fn.barycenter(self.x, weights)
+    return self.cost_fn.barycenter(self.x, weights)[0]
 
   @classmethod
   def prepare_divergences(

--- a/src/ott/math/utils.py
+++ b/src/ott/math/utils.py
@@ -146,7 +146,8 @@ def barycentric_projection(
   Returns:
     a vector of shape (n,) containing the barycentric projection of matrix.
   """
-  return jax.vmap(cost_fn.barycenter, in_axes=[0, None])(matrix, y)
+  return jax.vmap(lambda m, y : cost_fn.barycenter(m, y)[0],
+                  in_axes=[0, None])(matrix, y)
 
 
 softmin.defvjp(

--- a/src/ott/math/utils.py
+++ b/src/ott/math/utils.py
@@ -146,8 +146,9 @@ def barycentric_projection(
   Returns:
     a vector of shape (n,) containing the barycentric projection of matrix.
   """
-  return jax.vmap(lambda m, y : cost_fn.barycenter(m, y)[0],
-                  in_axes=[0, None])(matrix, y)
+  return jax.vmap(
+      lambda m, y: cost_fn.barycenter(m, y)[0], in_axes=[0, None]
+  )(matrix, y)
 
 
 softmin.defvjp(

--- a/src/ott/solvers/linear/continuous_barycenter.py
+++ b/src/ott/solvers/linear/continuous_barycenter.py
@@ -116,7 +116,7 @@ class FreeBarycenterState(NamedTuple):
     )
 
     x_new = jax.vmap(
-        bar_prob.cost_fn.barycenter, in_axes=[None, 1]
+        lambda w, y : bar_prob.cost_fn.barycenter(w,y)[0], in_axes=[None, 1]
     )(bar_prob.weights, barycenters_per_measure)
 
     return self.set(

--- a/src/ott/solvers/linear/continuous_barycenter.py
+++ b/src/ott/solvers/linear/continuous_barycenter.py
@@ -116,7 +116,7 @@ class FreeBarycenterState(NamedTuple):
     )
 
     x_new = jax.vmap(
-        lambda w, y : bar_prob.cost_fn.barycenter(w,y)[0], in_axes=[None, 1]
+        lambda w, y: bar_prob.cost_fn.barycenter(w, y)[0], in_axes=[None, 1]
     )(bar_prob.weights, barycenters_per_measure)
 
     return self.set(

--- a/tests/solvers/linear/sinkhorn_misc_test.py
+++ b/tests/solvers/linear/sinkhorn_misc_test.py
@@ -145,8 +145,9 @@ class TestSinkhornBures:
       cost_fn = costs.UnbalancedBures(dimension=self.dim, gamma=0.9, sigma=0.98)
     else:
       x, y = self.x, self.y
-      cost_fn = costs.Bures(dimension=self.dim,
-                            sqrtm_kw={'regularization':1e-4})
+      cost_fn = costs.Bures(
+          dimension=self.dim, sqrtm_kw={"regularization": 1e-4}
+      )
 
     geom = pointcloud.PointCloud(x, y, cost_fn=cost_fn, epsilon=self.eps)
     prob = linear_problem.LinearProblem(geom, self.a, self.b)

--- a/tests/solvers/linear/sinkhorn_misc_test.py
+++ b/tests/solvers/linear/sinkhorn_misc_test.py
@@ -145,7 +145,8 @@ class TestSinkhornBures:
       cost_fn = costs.UnbalancedBures(dimension=self.dim, gamma=0.9, sigma=0.98)
     else:
       x, y = self.x, self.y
-      cost_fn = costs.Bures(dimension=self.dim, regularization=1e-4)
+      cost_fn = costs.Bures(dimension=self.dim,
+                            sqrtm_kw={'regularization':1e-4})
 
     geom = pointcloud.PointCloud(x, y, cost_fn=cost_fn, epsilon=self.eps)
     prob = linear_problem.LinearProblem(geom, self.a, self.b)


### PR DESCRIPTION
Adds fine grained control on Gaussian (Bures) barycenters by allowing to parameterise:
- `kwargs` for the sqrtm calls used inside the barycenter
- length of the fixed point loop within barycenters.

Also, `def barycenter(...)` member functions in `cost_fn` are now expected to return a list, of which the barycenter is the first element, the second being any relevant auxiliary information on convergence. For Bures this is norms of successive differences between iterates.