### PR TITLE
introduce `ent_reg_cost` / `kl_reg_cost` in Sinkhorn to clarify which is returned to the user in `SinkhornOutput` objects.

### DIFF
--- a/docs/spelling/misc.txt
+++ b/docs/spelling/misc.txt
@@ -28,6 +28,7 @@ pre
 rng
 rngs
 sqeucl
+submodules
 topk
 vec
 wolfe

--- a/docs/spelling/misc.txt
+++ b/docs/spelling/misc.txt
@@ -28,7 +28,6 @@ pre
 rng
 rngs
 sqeucl
-submodules
 topk
 vec
 wolfe

--- a/docs/spelling/technical.txt
+++ b/docs/spelling/technical.txt
@@ -117,6 +117,7 @@ softplus
 stateful
 sublinear
 submodule
+submodules
 suboptimal
 subpopulation
 subpopulations

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -26,6 +26,7 @@ from typing import (
 
 import jax
 import jax.numpy as jnp
+import jax.scipy as jsp
 import numpy as np
 from jax.experimental import host_callback
 
@@ -320,27 +321,23 @@ class SinkhornOutput(NamedTuple):
   def ent_reg_cost(self) -> float:
     r"""Entropy regularized cost.
 
-    This outputs
-
-    :math:`\langle P^{\star},C\rangle> - \varepsilon H(P^{\star}),`
-
-    where :math:`P^{\star}` is the coupling returned by Sinkhorn.
+    This outputs :math:`\langle P^{\star},C\rangle - \varepsilon H(P^{\star}),`
+    where :math:`P^{\star}` is the coupling returned by the
+    :class:`~ott.solvers.linear.sinkhorn.Sinkhorn`.
     """
-    ent_a = jnp.sum(jax.scipy.special.entr(self.ot_prob.a))
-    ent_b = jnp.sum(jax.scipy.special.entr(self.ot_prob.b))
+    ent_a = jnp.sum(jsp.special.entr(self.ot_prob.a))
+    ent_b = jnp.sum(jsp.special.entr(self.ot_prob.b))
     return self.reg_ot_cost - self.geom.epsilon * (ent_a + ent_b)
 
   @property
   def kl_reg_cost(self) -> float:
     r"""KL regularized OT transport cost.
 
-    This outputs
-
-    :math:`\langle P^{\star}, C \rangle + \varepsilon KL(P^{\star},ab^T),`
-
-    where :math:`P^{\star}, a, b` are the coupling returned by the Sinkhorn
-    algorithm and the two marginal weight vectors. This coincides with
-    :attr:`reg_ot_cost`.
+    This outputs :math:`\langle P^{\star}, C \rangle +
+    \varepsilon KL(P^{\star},ab^T),` where :math:`P^{\star}, a, b` are the
+    coupling returned by the :class:`~ott.solvers.linear.sinkhorn.Sinkhorn`
+    algorithm and the two marginal weight vectors, respectively.
+    This coincides with :attr:`reg_ot_cost`.
     """
     return self.reg_ot_cost
 

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -316,6 +316,29 @@ class SinkhornOutput(NamedTuple):
     """Return transport cost of current solution at geometry."""
     return self.transport_cost_at_geom(other_geom=self.geom)
 
+  @property
+  def ent_reg_cost(self) -> float:
+    r"""Entropy regularized cost.
+
+    This outputs :math:`\\langle P^\\star,C> - \varepsilon H(P^\\star),
+
+    where :math:`P^\\star` is the coupling returned by Sinkhorn.
+    """
+    ent_a = jnp.sum(jax.scipy.special.entr(self.ot_prob.a))
+    ent_b = jnp.sum(jax.scipy.special.entr(self.ot_prob.b))
+    return self.reg_ot_cost - self.geom.epsilon * (ent_a + ent_b)
+
+  @property
+  def kl_reg_cost(self) -> float:
+    r"""KL regularized OT transport cost.
+
+    This outputs :math:`\\langle P^\\star,C> + \varepsilon KL(P^\\star,ab^T),
+
+    where :math:`P^\\star, a, b` are the coupling returned by Sinkhorn and the
+    two original marginal weight vectors. This coincides with `reg_ot_cost`.
+    """
+    return self.reg_ot_cost
+
   def transport_cost_at_geom(
       self, other_geom: geometry.Geometry
   ) -> jnp.ndarray:

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -322,9 +322,9 @@ class SinkhornOutput(NamedTuple):
 
     This outputs
 
-    :math:`\\langle P^\\star,C\\rangle> - \\varepsilon H(P^\\star) ,`
+    :math:`\langle P^{\star},C\rangle> - \varepsilon H(P^{\star}),`
 
-    where :math:`P^\\star` is the coupling returned by Sinkhorn.
+    where :math:`P^{\star}` is the coupling returned by Sinkhorn.
     """
     ent_a = jnp.sum(jax.scipy.special.entr(self.ot_prob.a))
     ent_b = jnp.sum(jax.scipy.special.entr(self.ot_prob.b))
@@ -336,10 +336,11 @@ class SinkhornOutput(NamedTuple):
 
     This outputs
 
-    :math:`\\langle P^\\star, C \\rangle + \\varepsilon KL(P^\\star,ab^T),`
+    :math:`\langle P^{\star}, C \rangle + \varepsilon KL(P^{\star},ab^T),`
 
-    where :math:`P^\\star, a, b` are the coupling returned by Sinkhorn and the
-    two original marginal weight vectors. This coincides with `reg_ot_cost`.
+    where :math:`P^{\star}, a, b` are the coupling returned by the Sinkhorn
+    algorithm and the two marginal weight vectors. This coincides with
+    :attr:`reg_ot_cost`.
     """
     return self.reg_ot_cost
 

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -320,7 +320,9 @@ class SinkhornOutput(NamedTuple):
   def ent_reg_cost(self) -> float:
     r"""Entropy regularized cost.
 
-    This outputs :math:`\\langle P^\\star,C> - \varepsilon H(P^\\star),
+    This outputs
+
+    :math:`\\langle P^\\star,C\\rangle> - \\varepsilon H(P^\\star) ,`
 
     where :math:`P^\\star` is the coupling returned by Sinkhorn.
     """
@@ -332,7 +334,9 @@ class SinkhornOutput(NamedTuple):
   def kl_reg_cost(self) -> float:
     r"""KL regularized OT transport cost.
 
-    This outputs :math:`\\langle P^\\star,C> + \varepsilon KL(P^\\star,ab^T),
+    This outputs
+
+    :math:`\\langle P^\\star, C \\rangle + \\varepsilon KL(P^\\star,ab^T),`
 
     where :math:`P^\\star, a, b` are the coupling returned by Sinkhorn and the
     two original marginal weight vectors. This coincides with `reg_ot_cost`.

--- a/src/ott/solvers/linear/sinkhorn_lr.py
+++ b/src/ott/solvers/linear/sinkhorn_lr.py
@@ -67,7 +67,7 @@ class LRSinkhornState(NamedTuple):
       ot_prob: linear_problem.LinearProblem,
       use_danskin: bool = False
   ) -> float:
-    """For LR sinkhorn, this defaults to the primal cost of LR solution."""
+    """For LR Sinkhorn, this defaults to the primal cost of LR solution."""
     return compute_reg_ot_cost(self.q, self.r, self.g, ot_prob, use_danskin)
 
   def solution_error(  # noqa: D102

--- a/src/ott/solvers/linear/sinkhorn_lr.py
+++ b/src/ott/solvers/linear/sinkhorn_lr.py
@@ -67,6 +67,7 @@ class LRSinkhornState(NamedTuple):
       ot_prob: linear_problem.LinearProblem,
       use_danskin: bool = False
   ) -> float:
+    """For LR sinkhorn, this defaults to the primal cost of LR solution."""
     return compute_reg_ot_cost(self.q, self.r, self.g, ot_prob, use_danskin)
 
   def solution_error(  # noqa: D102
@@ -86,7 +87,7 @@ def compute_reg_ot_cost(
     ot_prob: linear_problem.LinearProblem,
     use_danskin: bool = False
 ) -> float:
-  """Compute the regularized OT cost.
+  """Compute the regularized OT cost, here the primal cost of LR solution.
 
   Args:
     q: first factor of solution
@@ -97,7 +98,7 @@ def compute_reg_ot_cost(
       to avoid computing the gradient of the cost function.
 
   Returns:
-    regularized OT cost
+    regularized OT cost, here the (primal) transport cost of low-rank solution.
   """
   q = jax.lax.stop_gradient(q) if use_danskin else q
   r = jax.lax.stop_gradient(r) if use_danskin else r

--- a/src/ott/solvers/linear/sinkhorn_lr.py
+++ b/src/ott/solvers/linear/sinkhorn_lr.py
@@ -87,7 +87,7 @@ def compute_reg_ot_cost(
     ot_prob: linear_problem.LinearProblem,
     use_danskin: bool = False
 ) -> float:
-  """Compute the regularized OT cost, here the primal cost of LR solution.
+  """Compute the regularized OT cost, here the primal cost of the LR solution.
 
   Args:
     q: first factor of solution
@@ -98,7 +98,7 @@ def compute_reg_ot_cost(
       to avoid computing the gradient of the cost function.
 
   Returns:
-    regularized OT cost, here the (primal) transport cost of low-rank solution.
+    regularized OT cost, the (primal) transport cost of the low-rank solution.
   """
   q = jax.lax.stop_gradient(q) if use_danskin else q
   r = jax.lax.stop_gradient(r) if use_danskin else r

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -253,6 +253,14 @@ class TestSinkhorn:
     np.testing.assert_allclose(
         out_online.reg_ot_cost, out_batch.reg_ot_cost, rtol=1e-6
     )
+    np.testing.assert_allclose(
+        out_online.kl_reg_cost, out_batch.kl_reg_cost, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        out_online.ent_reg_cost, out_batch.ent_reg_cost, rtol=1e-6
+    )
+    # Check values are bigger than 0 for KL regularized OT.
+    np.testing.assert_array_less(0.0, out_online.kl_reg_cost)
     # check regularized transport matrices match
     np.testing.assert_allclose(
         online_geom.transport_from_potentials(out_online.f, out_online.g),


### PR DESCRIPTION
Currently, the Sinkhorn algorithm outputs the value `reg_ot_cost`, which is currently computed as the KL regularized OT problem's objective value. 

This can lead to confusion, since Sinkhorn is often described as "entropy regularized". The two are equivalent up to the addition of the entropies of the two marginal distributions `a` and `b`. This confusion is illustrated in, e.g. #361, at the end of the definition of the Monge gap, where @theouscidda6  had to correct `reg_ot_cost` by substracting again these 2 entropies to output the _entropy_ regularized OT objective. 

This PR clarifies this by introducing the two closely related `ent_reg..` and `kl_reg...` quantities, knowing that at the moment the "default" `reg_ot_cost` is `kl_reg_cost`. 

Note: It might be worth deprecating `reg_ot_cost` because of its ambiguity.