### PR TITLE
fix #375, `converged` flag when predefined number of iterations.

### DIFF
--- a/src/ott/math/fixed_point_loop.py
+++ b/src/ott/math/fixed_point_loop.py
@@ -27,31 +27,31 @@ def fixpoint_iter(
 ):
   """Implementation of a fixed point loop.
 
-  This fixed point loop iterator applies body_fn to a tuple
-  (iteration, constants, state, compute_error) to output a new state, using
+  This fixed point loop iterator applies ``body_fn`` to a tuple
+  ``(iteration, constants, state, compute_error)`` to output a new state, using
   context provided in iteration and constants.
 
-  body_fn is iterated (inner_iterations -1) times, and one last time with the
-  compute_error flag indicating that additional computational effort can be
-  spent on recalculating the latest error (errors are stored as the first
-  element of the state tuple).
+  ``body_fn`` is iterated (inner_iterations -1) times, and one last time with
+  the ``compute_error`` flag to ``True``, indicating that additional
+  computational effort can be spent on recalculating the latest error
+  (``errors`` are stored as the first element of the state tuple).
 
-  upon termination of these inner_iterations, the loop is continued if iteration
-  is smaller than min_iterations, stopped if equal/larger than max_iterations,
-  and interrupted if cond_fn returns False.
+  upon termination of these ``inner_iterations``, the loop is continued if
+  iteration is smaller than ``min_iterations``, stopped if equal/larger than
+  ``max_iterations``, and interrupted if ``cond_fn`` returns False.
 
   Args:
     cond_fn : termination condition function
     body_fn : body loop instructions
     min_iterations : lower bound on the total amount of fixed point iterations
     max_iterations : upper bound on the total amount of fixed point iterations
-    inner_iterations : number of iterations body_fn will be executed
-      successively before calling cond_fn.
+    inner_iterations : number of iterations ``body_fn`` will be executed
+      successively before calling ``cond_fn``.
     constants : constant (during loop) parameters passed on to body
     state : state variable
 
   Returns:
-    outputs state returned by body_fn upon termination.
+    outputs state returned by ``body_fn`` upon termination.
   """  # noqa: D401
   # If number of minimal iterations matches maximal number, force a scan instead
   # of a while loop.

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -1079,7 +1079,7 @@ class Sinkhorn:
     converged = jnp.logical_and(
         jnp.logical_not(jnp.any(jnp.isnan(state.errors))),
         state.errors[-1] < self.threshold
-    )
+    )[0]
 
     return SinkhornOutput(
         f=f,

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -291,7 +291,7 @@ class SinkhornOutput(NamedTuple):
   errors: Optional[jnp.ndarray] = None
   reg_ot_cost: Optional[float] = None
   ot_prob: Optional[linear_problem.LinearProblem] = None
-  threshold: Optional[float] = None
+  threshold: Optional[jnp.ndarray] = None
 
   def set(self, **kwargs: Any) -> "SinkhornOutput":
     """Return a copy of self, with potential overwrites."""
@@ -1044,7 +1044,10 @@ class Sinkhorn:
       f, g = state.recenter(f, g, ot_prob=ot_prob)
 
     return SinkhornOutput(
-        f=f, g=g, errors=state.errors[:, 0], threshold=self.threshold
+        f=f,
+        g=g,
+        errors=state.errors[:, 0],
+        threshold=jnp.array(self.threshold)
     )
 
   @property

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -291,6 +291,7 @@ class SinkhornOutput(NamedTuple):
   errors: Optional[jnp.ndarray] = None
   reg_ot_cost: Optional[float] = None
   ot_prob: Optional[linear_problem.LinearProblem] = None
+  threshold: Optional[float] = None
 
   def set(self, **kwargs: Any) -> "SinkhornOutput":
     """Return a copy of self, with potential overwrites."""
@@ -409,7 +410,8 @@ class SinkhornOutput(NamedTuple):
     if self.errors is None:
       return False
     return jnp.logical_and(
-        jnp.any(self.errors == -1), jnp.all(jnp.isfinite(self.errors))
+        jnp.logical_not(jnp.any(jnp.isnan(self.errors))),
+        self.errors[-1] < self.threshold
     )
 
   # TODO(michalk8): this should be always present
@@ -944,7 +946,10 @@ class Sinkhorn:
 
     # re-computes error if compute_error is True, else set it to inf.
     err = jax.lax.cond(
-        jnp.logical_and(compute_error, iteration >= self.min_iterations),
+        jnp.logical_or(
+            iteration == self.max_iterations - 1,
+            jnp.logical_and(compute_error, iteration >= self.min_iterations)
+        ),
         lambda state, prob: state.solution_error(
             prob,
             self.norm_error,
@@ -1038,7 +1043,9 @@ class Sinkhorn:
     if self.recenter_potentials:
       f, g = state.recenter(f, g, ot_prob=ot_prob)
 
-    return SinkhornOutput(f=f, g=g, errors=state.errors[:, 0])
+    return SinkhornOutput(
+        f=f, g=g, errors=state.errors[:, 0], threshold=self.threshold
+    )
 
   @property
   def norm_error(self) -> Tuple[int, ...]:

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -166,7 +166,11 @@ def _sinkhorn_divergence(
   out_xy = sinkhorn.solve(geometry_xy, a, b, **kwargs)
   out_xx = sinkhorn.solve(geometry_xx, a, a, **kwargs_symmetric)
   if geometry_yy is None:
-    out_yy = sinkhorn.SinkhornOutput(errors=jnp.array([]), reg_ot_cost=0.0)
+    # Create dummy output, corresponds to scenario where static_b is True.
+    # This choice ensures that `converged`` of this dummy output is True.
+    out_yy = sinkhorn.SinkhornOutput(
+        errors=jnp.array([-jnp.inf]), reg_ot_cost=0.0, threshold=0.0
+    )
   else:
     out_yy = sinkhorn.solve(geometry_yy, b, b, **kwargs_symmetric)
 

--- a/tests/solvers/linear/sinkhorn_misc_test.py
+++ b/tests/solvers/linear/sinkhorn_misc_test.py
@@ -351,12 +351,11 @@ class TestSinkhornJIT:
       """Assert SinkhornOutputs are close."""
       x = tuple(a for a in x if (a is not None and isinstance(a, jnp.ndarray)))
       y = tuple(a for a in y if (a is not None and isinstance(a, jnp.ndarray)))
-      return chex.assert_tree_all_close(x, y, atol=1e-6, rtol=0)
+      return chex.assert_trees_all_close(x, y, atol=1e-6, rtol=0)
 
     geom = self.geometry
     jitted_result = jax.jit(sinkhorn.solve)(geom, a=self.a, b=self.b)
     non_jitted_result = sinkhorn.solve(geom, a=self.a, b=self.b)
-
     assert_output_close(non_jitted_result, jitted_result)
 
   @pytest.mark.parametrize("implicit", [False, True])
@@ -382,5 +381,9 @@ class TestSinkhornJIT:
     jitted_loss, jitted_grad = jax.jit(val_grad)(self.a, self.x)
     non_jitted_loss, non_jitted_grad = val_grad(self.a, self.x)
 
-    chex.assert_tree_all_close(jitted_loss, non_jitted_loss, atol=1e-6, rtol=0.)
-    chex.assert_tree_all_close(jitted_grad, non_jitted_grad, atol=1e-6, rtol=0.)
+    chex.assert_trees_all_close(
+        jitted_loss, non_jitted_loss, atol=1e-6, rtol=0.
+    )
+    chex.assert_trees_all_close(
+        jitted_grad, non_jitted_grad, atol=1e-6, rtol=0.
+    )

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -187,6 +187,25 @@ class TestSinkhorn:
     assert errors[2] == jnp.inf
     assert errors[3] > 0
 
+  @pytest.mark.fast()
+  def test_euclidean_point_cloud_scan_loop(self):
+    """Testing the scan loop behavior."""
+    threshold = 1e-3
+    geom = pointcloud.PointCloud(self.x, self.y, epsilon=0.1)
+    out = sinkhorn.solve(
+        geom,
+        a=self.a,
+        b=self.b,
+        threshold=threshold,
+        min_iterations=50,
+        max_iterations=50
+    )
+    # Test converged flag is True despite running in scan mode
+    assert out.converged
+    # Test last error recomputed at the final iteration, and below threshold.
+    assert out.errors[-1] > 0
+    assert out.errors[-1] < threshold
+
   def test_geom_vs_point_cloud(self):
     """Two point clouds vs. simple cost_matrix execution of Sinkhorn."""
     geom_1 = pointcloud.PointCloud(self.x, self.y)


### PR DESCRIPTION
Fix #375

New way to compute ``converged`` property of ``SinkhornOutput`` objects. It was shown that when the number of iterations was predefined (this can be done setting ``min_iterations=max_iterations`` in the solver), the output was never marked as ``converged`` (the rule to test convergence was simply whether the iteration counter had reached ``max_iterations``.

This fix requires forces the (re?)computation of the ``error`` at the very last iteration, and to store the convergence ``threshold`` in the ``SinkhornOutput``, to compare it when ``converged`` is called.