### PR TITLE
A few changes to increase Coverage

### DIFF
--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -261,7 +261,10 @@ class Euclidean(CostFn):
 
 @jax.tree_util.register_pytree_node_class
 class SqEuclidean(TICost):
-  """Squared Euclidean distance."""
+  r"""Squared Euclidean distance.
+
+  Implemented as a translation invariant cost, :math:`h(z) = \|z\|^2`.
+  """
 
   def norm(self, x: jnp.ndarray) -> Union[float, jnp.ndarray]:
     """Compute squared Euclidean norm for vector."""

--- a/src/ott/problems/linear/potentials.py
+++ b/src/ott/problems/linear/potentials.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -28,10 +27,8 @@ import jax.scipy as jsp
 import jax.tree_util as jtu
 import numpy as np
 
+from ott.geometry import costs
 from ott.problems.linear import linear_problem
-
-if TYPE_CHECKING:
-  from ott.geometry import costs
 
 try:
   import matplotlib as mpl
@@ -69,6 +66,9 @@ class DualPotentials:
   ):
     self._f = f
     self._g = g
+    assert (
+        type(cost_fn) == costs.SqEuclidean or not corr
+    ), "Duals in `corr` form can only be used with a squared-Euclidean cost."
     self.cost_fn = cost_fn
     self._corr = corr
 
@@ -106,33 +106,34 @@ class DualPotentials:
     return vec - self._grad_h_inv(self._grad_g(vec))
 
   def distance(self, src: jnp.ndarray, tgt: jnp.ndarray) -> float:
-    r"""Evaluate 2-Wasserstein distance between samples using dual potentials.
+    r"""Evaluate Wasserstein distance between samples using dual potentials.
 
     This uses direct estimation of potentials against measures when dual
-    functions are provided in usual form. When potentials are given in
-    correlation form (i.e. they correspond to the minimization of the primal
-    where the transport cost is :math:`-2\\langle x,y\rangle`), this is
-    rearranged to take into account the residual squared norms.
+    functions are provided in usual form. This expression is valid for any
+    cost function.
+
+    When potentials are given in correlation form, as specified by the flag
+    ``corr``, the dual potentials solve the dual problem corresponding to the
+    minimization of the primal OT problem where the ground cost is
+    :math:`-2\langle x,y\rangle`. To recover the (squared) 2-Wasserstein
+    distance, terms are re-arranged and contributions from squared norms are
+    taken into account.
 
     Args:
       src: Samples from the source distribution, array of shape ``[n, d]``.
       tgt: Samples from the target distribution, array of shape ``[m, d]``.
 
     Returns:
-      Wasserstein distance.
+      Wasserstein distance using specified cost function.
     """
     src, tgt = jnp.atleast_2d(src), jnp.atleast_2d(tgt)
     f = jax.vmap(self.f)
     g = jax.vmap(self.g)
-
+    out = jnp.mean(f(src)) + jnp.mean(g(tgt))
     if self._corr:
-      out = jnp.mean(jnp.sum(src ** 2, axis=-1))
+      out = -2.0 * out + jnp.mean(jnp.sum(src ** 2, axis=-1))
       out += jnp.mean(jnp.sum(tgt ** 2, axis=-1))
-      out -= 2.0 * (jnp.mean(f(src)) + jnp.mean(g(tgt)))
-      return out
-
-    g = jax.vmap(self.g)
-    return jnp.mean(f(src)) + jnp.mean(g(tgt))
+    return out
 
   @property
   def f(self) -> Potential_t:

--- a/src/ott/problems/linear/potentials.py
+++ b/src/ott/problems/linear/potentials.py
@@ -67,7 +67,7 @@ class DualPotentials:
     self._f = f
     self._g = g
     assert (
-        type(cost_fn) == costs.SqEuclidean or not corr
+        not corr or type(cost_fn) == costs.SqEuclidean
     ), "Duals in `corr` form can only be used with a squared-Euclidean cost."
     self.cost_fn = cost_fn
     self._corr = corr

--- a/src/ott/problems/linear/potentials.py
+++ b/src/ott/problems/linear/potentials.py
@@ -106,11 +106,13 @@ class DualPotentials:
     return vec - self._grad_h_inv(self._grad_g(vec))
 
   def distance(self, src: jnp.ndarray, tgt: jnp.ndarray) -> float:
-    """Evaluate 2-Wasserstein distance between samples using dual potentials.
+    r"""Evaluate 2-Wasserstein distance between samples using dual potentials.
 
     This uses direct estimation of potentials against measures when dual
-    functions are provided in usual form, and renormalizes w.r.t. data when
-    given in dual form.
+    functions are provided in usual form. When potentials are given in
+    correlation form (i.e. they correspond to the minimization of the primal
+    where the transport cost is :math:`-2\\langle x,y\rangle`), this is
+    rearranged to take into account the residual squared norms.
 
     Args:
       src: Samples from the source distribution, array of shape ``[n, d]``.

--- a/src/ott/problems/linear/potentials.py
+++ b/src/ott/problems/linear/potentials.py
@@ -61,7 +61,7 @@ class DualPotentials:
       f: Potential_t,
       g: Potential_t,
       *,
-      cost_fn: "costs.CostFn",
+      cost_fn: costs.CostFn,
       corr: bool = False
   ):
     self._f = f

--- a/src/ott/solvers/linear/continuous_barycenter.py
+++ b/src/ott/solvers/linear/continuous_barycenter.py
@@ -89,12 +89,6 @@ class FreeBarycenterState(NamedTuple):
           out.errors if store_errors else None
       )
 
-    if bar_prob.debiased:
-      raise NotImplementedError(
-          "Debiased version of continuous Wasserstein barycenter "
-          "not yet implemented."
-      )
-
     reg_ot_costs, convergeds, matrices, errors = solve_linear_ot(
         self.a, self.x, seg_b, seg_y
     )

--- a/tests/solvers/linear/discrete_barycenter_test.py
+++ b/tests/solvers/linear/discrete_barycenter_test.py
@@ -48,7 +48,9 @@ class TestDiscreteBarycenter:
     a2 /= jnp.sum(a2)
     threshold = 1e-2
 
-    fixed_bp = bp.FixedBarycenterProblem(geom=grid_3d, a=jnp.stack((a1, a2)))
+    fixed_bp = bp.FixedBarycenterProblem(
+        geom=grid_3d, a=jnp.stack((a1, a2)), weights=jnp.array([0.5, 0.5])
+    )
     solver = db.FixedBarycenter(
         threshold=threshold, lse_mode=lse_mode, debiased=debiased
     )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import Optional
 
+import jax.numpy as jnp
 import pytest
 from ott import utils
 
@@ -36,3 +37,9 @@ def test_deprecation_warning(version: Optional[str], msg: Optional[str]):
   with pytest.warns(DeprecationWarning, match=expected_msg):
     res = func()
   assert res == 42
+
+
+def test_is_jax_array():
+  x = jnp.array([0.0])
+  assert utils.is_jax_array(x)
+  assert not utils.is_jax_array(0)


### PR DESCRIPTION
- discard stale `debiased` option in continuous barycenters, `FreeWassersteinBarycenter` (problems and solvers).
- fix the distance calculation of potentials in correlation form + test it. Note that correlation form cannot be tested at the moment using Sinkhorn estimator (no twist cost implemented yet).