### PR TITLE
rename `ent_reg_cost` in sinkhorn solver

### DIFF
--- a/src/ott/initializers/nn/initializers.py
+++ b/src/ott/initializers/nn/initializers.py
@@ -177,7 +177,9 @@ class MetaInitializer(initializers.DefaultInitializer):
       g_pred = jnp.where(jnp.isfinite(g_pred), g_pred, 0.)
 
       ot_prob = linear_problem.LinearProblem(geom=self.geom, a=a, b=b)
-      dual_obj = sinkhorn.ent_reg_cost(f_pred, g_pred, ot_prob, lse_mode=True)
+      dual_obj = sinkhorn.compute_kl_reg_cost(
+          f_pred, g_pred, ot_prob, lse_mode=True
+      )
       loss = -dual_obj
       return loss, f_pred
 

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -85,10 +85,10 @@ class SinkhornState(NamedTuple):
         parallel_dual_updates=parallel_dual_updates
     )
 
-  def ent_reg_cost(  # noqa: D102
+  def compute_kl_reg_cost(  # noqa: D102
       self, ot_prob: linear_problem.LinearProblem, lse_mode: bool
   ) -> float:
-    return ent_reg_cost(self.fu, self.gv, ot_prob, lse_mode)
+    return compute_kl_reg_cost(self.fu, self.gv, ot_prob, lse_mode)
 
   def recenter(
       self,
@@ -228,7 +228,7 @@ def marginal_error(
   ) ** (1.0 / norm_error)
 
 
-def ent_reg_cost(
+def compute_kl_reg_cost(
     f: jnp.ndarray, g: jnp.ndarray, ot_prob: linear_problem.LinearProblem,
     lse_mode: bool
 ) -> float:
@@ -336,7 +336,7 @@ class SinkhornOutput(NamedTuple):
   ) -> "SinkhornOutput":
     f = jax.lax.stop_gradient(self.f) if use_danskin else self.f
     g = jax.lax.stop_gradient(self.g) if use_danskin else self.g
-    return self.set(reg_ot_cost=ent_reg_cost(f, g, ot_prob, lse_mode))
+    return self.set(reg_ot_cost=compute_kl_reg_cost(f, g, ot_prob, lse_mode))
 
   @property
   def dual_cost(self) -> jnp.ndarray:


### PR DESCRIPTION
in `sinkhorn.py`, `ent_reg_cost` is used for a property of `SinkhornOutput` (see e.g. #376) but also as a method of the solver. This PR disambiguates both (and renames properly the method in the solver)