### PR TITLE
first lb -> third lb

### DIFF
--- a/src/ott/solvers/quadratic/lower_bound.py
+++ b/src/ott/solvers/quadratic/lower_bound.py
@@ -32,7 +32,7 @@ class LowerBoundSolver:
     As implemented, this solver assumes uniform marginals,
     non-uniform marginal solver coming soon!
 
-  Computes the first lower bound distance from :cite:`memoli:11`, def. 6.1.
+  Computes the third lower bound distance from :cite:`memoli:11`, def. 6.3.
   there is an uneven number of points in the distributions, then we perform a
   stratified subsample of the distribution of distances to approximate
   the Wasserstein distance between the local distributions of distances.


### PR DESCRIPTION
I accidentally have been referencing this as the first lower bound, when it is in fact, the _third_ lower bound from [Memoli 2011]. I only realized this when I was looking at the paper for other reasons. I'm pretty sure this should involve only changing the docstring here.