### PR TITLE
refactoring ``UnivariateSolver``

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -66,6 +66,7 @@ Cost Functions
     costs.ElasticSTVS
     costs.ElasticSqKOverlap
     costs.SoftDTW
+    distrib_costs.UnivariateWasserstein
 
 Utilities
 ---------

--- a/src/ott/geometry/__init__.py
+++ b/src/ott/geometry/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from . import (
     costs,
+    distrib_costs,
     epsilon_scheduler,
     geometry,
     graph,

--- a/src/ott/geometry/distrib_cost.py
+++ b/src/ott/geometry/distrib_cost.py
@@ -1,0 +1,82 @@
+# Copyright OTT-JAX
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Optional
+
+import jax
+import jax.numpy as jnp
+
+from ott.geometry import costs, pointcloud
+from ott.problems.linear import linear_problem
+from ott.solvers.linear import univariate
+
+__all__ = [
+    "UnivariateWasserstein",
+]
+
+
+@jax.tree_util.register_pytree_node_class
+class UnivariateWasserstein(costs.CostFn):
+  """1D Wasserstein cost for two 1D distributions.
+
+  This ground cost between considers vectors as a family of values. The
+  Wasserstein distance between them is the 1D OT cost, using a user-defined
+  ground cost.
+  """
+
+  def __init__(
+      self,
+      ground_cost: Optional[costs.TICost] = None,
+      kwargs_solve: Optional[Any] = None,
+      **kwargs: Any
+  ):
+    super().__init__()
+    if ground_cost is None:
+      self.ground_cost = costs.SqEuclidean()
+    else:
+      self.ground_cost = ground_cost
+    self._kwargs_solve = {} if kwargs_solve is None else kwargs_solve
+    self._kwargs = kwargs
+    self._solver = univariate.UnivariateSolver(**kwargs)
+
+  def pairwise(self, x: jnp.ndarray, y: jnp.ndarray) -> float:
+    """Wasserstein distance between :math:`x` and :math:`y` seen as a 1D dist.
+
+    Args:
+      x: vector
+      y: vector
+      kwargs: arguments passed on when calling the
+        :class:`~ott.solvers.linear.univariate.UnivariateSolver`. May include
+        random key, or specific instructions to subsample or compute using
+        quantiles.
+
+    Returns:
+      The transport cost.
+    """
+    out = self._solver(
+        linear_problem.LinearProblem(
+            pointcloud.PointCloud(
+                x[:, None], y[:, None], cost_fn=self.ground_cost
+            )
+        ), **self._kwargs_solve
+    )
+    return jnp.squeeze(out.ot_costs)
+
+  def tree_flatten(self):  # noqa: D102
+    return (), (self.ground_cost, self._kwargs_solve, self._kwargs)
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children):  # noqa: D102
+    del children
+    gc, kws, kw = aux_data
+    return cls(gc, kws, **kw)

--- a/src/ott/geometry/distrib_costs.py
+++ b/src/ott/geometry/distrib_costs.py
@@ -47,6 +47,7 @@ class UnivariateWasserstein(costs.CostFn):
       solver: Optional[univariate.UnivariateSolver] = None,
       **kwargs: Any
   ):
+    from ott.solvers.linear import univariate
     super().__init__()
 
     self.ground_cost = (
@@ -71,13 +72,13 @@ class UnivariateWasserstein(costs.CostFn):
             pointcloud.PointCloud(
                 x[:, None], y[:, None], cost_fn=self.ground_cost
             )
-        ), **self._kwargs_solve
+        )
     )
     return jnp.squeeze(out.ot_costs)
 
   def tree_flatten(self):  # noqa: D102
-    return (self.ground_cost, self._solver), self._kwargs_solve
+    return (self.ground_cost,), (self._solver,)
 
   @classmethod
   def tree_unflatten(cls, aux_data, children):  # noqa: D102
-    return cls(*children, **aux_data)
+    return cls(*children, *aux_data)

--- a/src/ott/geometry/distrib_costs.py
+++ b/src/ott/geometry/distrib_costs.py
@@ -72,7 +72,7 @@ class UnivariateWasserstein(costs.CostFn):
             pointcloud.PointCloud(
                 x[:, None], y[:, None], cost_fn=self.ground_cost
             )
-        )
+        ), **self._kwargs_solve
     )
     return jnp.squeeze(out.ot_costs)
 

--- a/src/ott/math/utils.py
+++ b/src/ott/math/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
-from typing import TYPE_CHECKING, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -29,6 +29,7 @@ __all__ = [
     "gen_js",
     "logsumexp",
     "softmin",
+    "sort_and_argsort",
     "barycentric_projection",
 ]
 
@@ -220,3 +221,15 @@ def barycentric_projection(
   return jax.vmap(
       lambda m, y: cost_fn.barycenter(m, y)[0], in_axes=[0, None]
   )(matrix, y)
+
+
+def sort_and_argsort(
+    x: jnp.array,
+    *,
+    argsort: bool = False
+) -> Tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+  """Unified function that returns both sort and argsort, if latter needed."""
+  if argsort:
+    i_x = jnp.argsort(x)
+    return x[i_x], i_x
+  return jnp.sort(x), None

--- a/src/ott/problems/linear/linear_problem.py
+++ b/src/ott/problems/linear/linear_problem.py
@@ -79,6 +79,16 @@ class LinearProblem:
     return self.tau_a == 1.0 and self.tau_b == 1.0
 
   @property
+  def is_uniform(self) -> bool:
+    """Test if no weights were passed."""
+    return self._a is None and self._b is None
+
+  @property
+  def is_equal_size(self) -> bool:
+    """Test if square shape, i.e. n == m."""
+    return self.geom.shape[0] == self.geom.shape[1]
+
+  @property
   def epsilon(self) -> float:
     """Entropic regularization."""
     return self.geom.epsilon

--- a/src/ott/problems/linear/linear_problem.py
+++ b/src/ott/problems/linear/linear_problem.py
@@ -80,12 +80,12 @@ class LinearProblem:
 
   @property
   def is_uniform(self) -> bool:
-    """Test if no weights were passed."""
+    """True if no weights ``a,b`` were passed, and have defaulted to uniform."""
     return self._a is None and self._b is None
 
   @property
   def is_equal_size(self) -> bool:
-    """Test if square shape, i.e. n == m."""
+    """True if square shape, i.e. ``n == m``."""
     return self.geom.shape[0] == self.geom.shape[1]
 
   @property

--- a/src/ott/solvers/linear/univariate.py
+++ b/src/ott/solvers/linear/univariate.py
@@ -49,12 +49,11 @@ class UnivariateOutput(NamedTuple):  # noqa: D101
       ``0<=k<m+n``, and ``0<=s<d``  then writing ``i:=paired_indices[s,0,k]``
       and ``j=paired_indices[s,1,k]``, point ``i`` sends
       ``mass_paired_indices[s,k]`` to point ``j``.
-
   """
   prob: linear_problem.LinearProblem
   ot_costs: float
-  paired_indices: Optional[jnp.ndarray]
-  mass_paired_indices: Optional[jnp.ndarray]
+  paired_indices: Optional[jnp.ndarray] = None
+  mass_paired_indices: Optional[jnp.ndarray] = None
 
   @property
   def transport_matrices(self) -> jnp.ndarray:
@@ -64,8 +63,8 @@ class UnivariateOutput(NamedTuple):  # noqa: D101
     non-zero values, out of ``dnm`` total entries.
     """
     assert self.paired_indices is not None, \
-      ("[d, n, m] tensor of transports cannot be computed, likely because an"+
-       " approximate method was used (using either subsampling or quantiles).")
+      "[d, n, m] tensor of transports cannot be computed, likely because an" \
+      " approximate method was used (using either subsampling or quantiles)."
 
     n, m = self.prob.geom.shape
     if self.prob.is_equal_size and self.prob.is_uniform:

--- a/src/ott/solvers/linear/univariate.py
+++ b/src/ott/solvers/linear/univariate.py
@@ -12,133 +12,246 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Literal, Optional
+from typing import NamedTuple, Optional, Union
 
 import jax
 import jax.numpy as jnp
 
-from ott.geometry import costs
+from ott.geometry import costs, pointcloud
+from ott.problems.linear import linear_problem
 
-__all__ = ["UnivariateSolver"]
+__all__ = ["UnivariateOutput", "UnivariateSolver"]
+
+
+class UnivariateOutput(NamedTuple):  # noqa: D101
+  prob: linear_problem.LinearProblem
+  ot_costs: float
+  paired_indices: jax.Array
+  mass_paired_indices: jax.Array
+
+  @property
+  def transport_matrices(self) -> jax.Array:
+    """Output a ``[d,n,m]`` tensor of all ``[n,m]`` transport matrices."""
+    assert self.paired_indices is not None, "[d,n,m] Transports *not* computed"
+
+    n, m = self.prob.geom.shape
+    if self.prob.is_equal_size and self.prob.is_uniform:
+      transport_matrices_from_indices = jax.vmap(
+          lambda idx, idy: jnp.eye(n)[idx, :][:, idy].T, in_axes=[0, 0]
+      )
+      return transport_matrices_from_indices(
+          self.paired_indices[:, 0, :], self.paired_indices[:, 1, :]
+      )
+
+    # raveled indexing of entries.
+    indices = self.paired_indices[:, 0] * m + self.paired_indices[:, 1]
+    # segment sum is needed to collect several contributions
+    return jax.vmap(
+        lambda idx, mass: jax.ops.segment_sum(
+            mass, idx, indices_are_sorted=True, num_segments=n * m
+        ).reshape(n, m),
+        in_axes=[0, 0]
+    )(indices, self.mass_paired_indices)
+
+  @property
+  def mean_transport_matrix(self) -> jax.Array:
+    """Return the mean tranport matrix, averaged over slices."""
+    return jnp.mean(self.transport_matrices, axis=0)
 
 
 @jax.tree_util.register_pytree_node_class
 class UnivariateSolver:
-  r"""1-D OT solver.
+  r"""Univariate solver to compute 1D OT distance over slices of data.
 
-  .. warning::
-    This solver assumes uniform marginals, a non-uniform marginal solver
-    is coming soon.
+  Computes 1-Dimensional optimal transport distance between two $d$-dimensional
+  point clouds. The total distance is the sum of univariate Wasserstein
+  distances on the $d$ slices of data: given two weighted point-clouds, stored
+  as ``[n,d]`` and ``[m,d]`` in a
+  :class:`~ott.problems.linear.linear_problem.LinearProblem` object, with
+  respective weights ``a`` and ``b``, the solver
+  computes ``d`` OT distances between each of these ``[n,1]`` and ``[m,1]``
+  slices. The distance is computed using the analytical formula by default,
+  which involves sorting each of the slices independently. The optimal transport
+  matrices are also outputted when possible (described in sparse form, i.e.
+  pairs of indices and mass transferred between those indices).
 
-  Computes the 1-Dimensional optimal transport distance between two histograms.
+  When weights ``a`` and ``b`` are uniform, and ``n=m``, the computation only
+  involves comparing sorted entries per slice, and ``d`` assignments are given.
+
+  The user may also supply a ``num_subsamples`` parameter to extract as many
+  points from the original point cloud, sampled with probability masses ``a``
+  and ``b``. This then simply applied the method above to the subsamples, to
+  output ``d`` costs, but assignments are not provided.
+
+  When the problem is not uniform or not of equal size, the method defaults to
+  an inversion of the CDF, and outputs both costs and transport matrix in sparse
+  form.
+
+  When a ``quantiles`` argument is passed, either specifying explicit quantiles
+  or a grid of quantiles, the distance is evaluated by comparing the quantiles
+  of the two point clouds on each slice. The OT costs are returned but
+  assignments are not provided.
 
   Args:
-    sort_fn: The sorting function. If :obj:`None`,
-      use :func:`hard-sorting <jax.numpy.sort>`.
-    cost_fn: The cost function for transport. If :obj:`None`, defaults to
-      :class:`PNormP(2) <ott.geometry.costs.PNormP>`.
-    method: The method used for computing the distance on the line. Options
-      currently supported are:
-
-      - `'subsample'` - Take a stratified sub-sample of the distances.
-      - `'quantile'` - Take equally spaced quantiles of the distances.
-      - `'equal'` - No subsampling is performed, requires distributions to have
-        the same number of points.
-      - `'wasserstein'` - Compute the distance using the explicit solution
-        involving inverse CDFs.
-
-    n_subsamples: The number of samples to draw for the "quantile" or
-      "subsample" methods.
+    num_subsamples: option to reduce the size of inputs by doing random
+      subsampling, taken into account marginal probabilities.
+    quantiles: When a vector or a number of quantiles is passed, the distance
+      is computed by evaluating the cost function on the sectional (one for each
+      dimension) quantiles of the two point cloud distributions described in the
+      problem.
   """
 
   def __init__(
       self,
-      sort_fn: Optional[Callable[[jnp.ndarray], jnp.ndarray]] = None,
-      cost_fn: Optional[costs.CostFn] = None,
-      method: Literal["subsample", "quantile", "wasserstein",
-                      "equal"] = "subsample",
-      n_subsamples: int = 100,
+      num_subsamples: Optional[int] = None,
+      quantiles: Optional[Union[int, jnp.ndarray]] = None,
   ):
-    self.sort_fn = jnp.sort if sort_fn is None else sort_fn
-    self.cost_fn = costs.PNormP(2) if cost_fn is None else cost_fn
-    self.method = method
-    self.n_subsamples = n_subsamples
+    self._quantiles = quantiles
+    self.num_subsamples = num_subsamples
+
+  @property
+  def quantiles(self):
+    """Quantiles' values used to evaluate OT cost."""
+    if self._quantiles is None:
+      return None
+    if isinstance(self._quantiles, int):
+      return jnp.linspace(0.0, 1.0, self._quantiles)
+    return self._quantiles
+
+  @property
+  def num_quantiles(self):
+    """Number of quantiles used to evaluate OT cost."""
+    return 0 if self._quantiles is None else self.quantiles.shape[0]
 
   def __call__(
       self,
-      x: jnp.ndarray,
-      y: jnp.ndarray,
-      a: Optional[jnp.ndarray] = None,
-      b: Optional[jnp.ndarray] = None
+      prob: linear_problem.LinearProblem,
+      rng: Optional[jax.Array] = None,
   ) -> float:
-    """Computes the Univariate OT Distance between `x` and `y`.
+    """Computes Univariate Distance between the `d` dimensional slices.
 
     Args:
-      x: The first distribution of shape ``[n,]`` or ``[n, 1]``.
-      y: The second distribution of shape ``[m,]`` or ``[m, 1]``.
-      a: The first marginals when ``method = 'wasserstein'``. If :obj:`None`,
-        uniform will be used.
-      b: The second marginals when ``method = 'wasserstein'``. If :obj:`None`,
-        uniform will be used.
+      prob: describing, in its geometry attribute, the two point clouds
+        ``x`` and ``y`` (of respective sizes ``[n,d]`` and ``[m,d]``) and
+        a ground ``cost_fn`` for between two scalars. The ``[n,]`` and ``[m,]``
+        size probability weights vectors are stored in attributes ``a`` and
+        ``b``.
+      rng: used for random downsampling, if used.
+      return_transport: whether to return an average transport matrix (across
+        slices). Not available when approximating the distance computation
+        using subsamples, or quantiles.
 
     Returns:
-      The OT distance.
+      The OT distance, and possibly the transport matrix averaged by
+        considering all matrices arising from 1D transport on each of the ``d``
+        dimensional slices of the input.
     """
-    x = x.squeeze(-1) if x.ndim == 2 else x
-    y = y.squeeze(-1) if y.ndim == 2 else y
-    assert x.ndim == 1, x.ndim
-    assert y.ndim == 1, y.ndim
+    geom = prob.geom
+    n, m = geom.shape
+    rng = jax.random.PRNGKey(0) if rng is None else rng
+    geom_is_pc = isinstance(geom, pointcloud.PointCloud)
+    assert geom_is_pc, "Geometry object in problem must be a PointCloud."
+    cost_is_TI = isinstance(geom.cost_fn, costs.TICost)
+    assert cost_is_TI, "Geometry's cost must be translation invariant."
+    x, y = geom.x, geom.y
 
-    n, m = x.shape[0], y.shape[0]
+    # check if problem has the property uniform / same number of points
+    is_uniform_same_size = prob.is_uniform and prob.is_equal_size
+    if self.num_subsamples:
+      rng1, rng2 = jax.random.split(rng, 2)
+      if prob.is_uniform:
+        x = x[jnp.linspace(0, n, num=self.num_subsamples).astype(int), :]
+        y = y[jnp.linspace(0, m, num=self.num_subsamples).astype(int), :]
+      else:
+        x = jax.random.choice(rng1, x, (self.num_subsamples,), p=prob.a, axis=0)
+        y = jax.random.choice(rng2, y, (self.num_subsamples,), p=prob.b, axis=0)
+        n = m = self.num_subsamples
+      # now that both are subsampled, consider them as uniform/same size.
+      is_uniform_same_size = True
 
-    if self.method == "equal":
-      xx, yy = self.sort_fn(x), self.sort_fn(y)
-    elif self.method == "subsample":
-      assert self.n_subsamples <= n, (self.n_subsamples, x)
-      assert self.n_subsamples <= m, (self.n_subsamples, y)
+    if self.quantiles is None:
+      if is_uniform_same_size:
+        i_x, i_y = jnp.argsort(x, axis=0), jnp.argsort(y, axis=0)
+        x = jnp.take_along_axis(x, i_x, axis=0)
+        y = jnp.take_along_axis(y, i_y, axis=0)
+        ot_costs = jax.vmap(geom.cost_fn.h, in_axes=[0])(x.T - y.T) / n
 
-      sorted_x, sorted_y = self.sort_fn(x), self.sort_fn(y)
-      xx = sorted_x[jnp.linspace(0, n, num=self.n_subsamples).astype(int)]
-      yy = sorted_y[jnp.linspace(0, m, num=self.n_subsamples).astype(int)]
-    elif self.method == "quantile":
-      sorted_x, sorted_y = self.sort_fn(x), self.sort_fn(y)
-      xx = jnp.quantile(sorted_x, q=jnp.linspace(0, 1, self.n_subsamples))
-      yy = jnp.quantile(sorted_y, q=jnp.linspace(0, 1, self.n_subsamples))
-    elif self.method == "wasserstein":
-      return self._cdf_distance(x, y, a, b)
+        if self.num_subsamples:
+          # When subsampling, the pairing computed have no meaning w.r.t.
+          # original data.
+          paired_indices, mass_paired_indices = None, None
+        else:
+          paired_indices = jnp.stack([i_x, i_y]).transpose([2, 0, 1])
+          mass_paired_indices = jnp.ones((n,)) / n
+
+      else:
+        ot_costs, paired_indices, mass_paired_indices = jax.vmap(
+            self._quantile_distance_and_transport,
+            in_axes=[1, 1, None, None, None]
+        )(x, y, prob.a, prob.b, geom.cost_fn)
+
     else:
-      raise NotImplementedError(f"Method `{self.method}` not implemented.")
+      assert prob.is_uniform, "Quantile method only valid for uniform marginals"
+      x_q = jnp.quantile(x, self.quantiles, axis=0)
+      y_q = jnp.quantile(y, self.quantiles, axis=0)
+      ot_costs = jax.vmap(geom.cost_fn.pairwise, in_axes=[1, 1])(x_q, y_q)
+      ot_costs /= self.num_quantiles
+      paired_indices = None
+      mass_paired_indices = None
 
-    # re-scale when subsampling
-    return self.cost_fn.pairwise(xx, yy) * (n / xx.shape[0])
+    return UnivariateOutput(
+        prob=prob,
+        ot_costs=ot_costs,
+        paired_indices=paired_indices,
+        mass_paired_indices=mass_paired_indices
+    )
 
-  def _cdf_distance(
-      self, x: jnp.ndarray, y: jnp.ndarray, a: Optional[jnp.ndarray],
-      b: Optional[jnp.ndarray]
+  def _quantile_distance_and_transport(
+      self, x: jnp.ndarray, y: jnp.ndarray, a: jnp.ndarray, b: jnp.ndarray,
+      cost_fn: costs.TICost
   ):
-    # Implementation based on `scipy` implementation for
+    # Implementation inspired by `scipy` implementation for
     # :func:<scipy.stats.wasserstein_distance>
-    a = jnp.ones_like(x) if a is None else a
-    a /= jnp.sum(a)
-    b = jnp.ones_like(y) if b is None else b
-    b /= jnp.sum(b)
+    def sort_and_argsort(x: jnp.array, return_argsort: bool, **kwargs):
+      if return_argsort:
+        i_x = jnp.argsort(x, **kwargs)
+        return x[i_x], i_x
+      return jnp.sort(x), None
+
+    x, i_x = sort_and_argsort(x, True)
+    y, i_y = sort_and_argsort(y, True)
 
     all_values = jnp.concatenate([x, y])
-    all_values_sorter = jnp.argsort(all_values)
-    all_values_sorted = all_values[all_values_sorter]
-    x_pdf = jnp.concatenate([a, jnp.zeros(y.shape)])[all_values_sorter]
-    y_pdf = jnp.concatenate([jnp.zeros(x.shape), b])[all_values_sorter]
+    all_values_sorted, all_values_sorter = sort_and_argsort(all_values, True)
+
+    x_pdf = jnp.concatenate([a[i_x], jnp.zeros_like(b)])[all_values_sorter]
+    y_pdf = jnp.concatenate([jnp.zeros_like(a), b[i_y]])[all_values_sorter]
 
     x_cdf = jnp.cumsum(x_pdf)
     y_cdf = jnp.cumsum(y_pdf)
 
-    quantiles = jnp.sort(jnp.concatenate([x_cdf, y_cdf]))
-    x_cdf_inv = all_values_sorted[jnp.searchsorted(x_cdf, quantiles)]
-    y_cdf_inv = all_values_sorted[jnp.searchsorted(y_cdf, quantiles)]
-    return jnp.sum(
-        jax.vmap(self.cost_fn)(y_cdf_inv[1:, None], x_cdf_inv[1:, None]) *
-        jnp.diff(quantiles)
+    x_y_cdfs = jnp.concatenate([x_cdf, y_cdf])
+    quantile_levels, _ = sort_and_argsort(x_y_cdfs, False)
+
+    i_x_cdf_inv = jnp.searchsorted(x_cdf, quantile_levels)
+    x_cdf_inv = all_values_sorted[i_x_cdf_inv]
+    i_y_cdf_inv = jnp.searchsorted(y_cdf, quantile_levels)
+    y_cdf_inv = all_values_sorted[i_y_cdf_inv]
+
+    diff_q = jnp.diff(quantile_levels)
+    cost = jnp.sum(
+        jax.vmap(cost_fn.h)(y_cdf_inv[1:, None] - x_cdf_inv[1:, None]) * diff_q
     )
+
+    n = x.shape[0]
+
+    i_in_sorted_x_of_quantile = all_values_sorter[i_x_cdf_inv] % n
+    i_in_sorted_y_of_quantile = all_values_sorter[i_y_cdf_inv] - n
+
+    orig_i = (i_x[i_in_sorted_x_of_quantile])[1:]
+    orig_j = (i_y[i_in_sorted_y_of_quantile])[1:]
+
+    return cost, jnp.stack([orig_i, orig_j]), diff_q
 
   def tree_flatten(self):  # noqa: D102
     aux_data = vars(self).copy()

--- a/src/ott/solvers/linear/univariate.py
+++ b/src/ott/solvers/linear/univariate.py
@@ -180,7 +180,7 @@ class UnivariateSolver:
     """
     geom = prob.geom
     n, m = geom.shape
-    rng = utils.default_prng_key(rng) if rng is None else rng
+    rng = utils.default_prng_key(rng)
     assert isinstance(geom, pointcloud.PointCloud), \
       "Geometry object in problem must be a PointCloud."
     assert isinstance(geom.cost_fn, costs.TICost), \
@@ -208,8 +208,7 @@ class UnivariateSolver:
         )
       else:
         ot_costs, paired_indices, mass_paired_indices = jax.vmap(
-            self._quantile_distance_and_transport,
-            in_axes=[1, 1, None, None, None]
+            quantile_distance, in_axes=[1, 1, None, None, None]
         )(x, y, prob.a, prob.b, geom.cost_fn)
 
     else:
@@ -230,12 +229,12 @@ class UnivariateSolver:
     )
 
   def tree_flatten(self):  # noqa: D102
-    aux_data = vars(self).copy()
-    return [], aux_data
+    return None, (self.num_subsamples, self._quantiles)
 
   @classmethod
   def tree_unflatten(cls, aux_data, children):  # noqa: D102
-    return cls(*children, **aux_data)
+    del children
+    return cls(*aux_data)
 
 
 def uniform_distance(

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -51,7 +51,7 @@ class SinkhornDivergenceOutput:  # noqa: D101
         f_xy, g_xy, prob_xy, f_xx=f_x, g_yy=g_y
     )
 
-  def tree_flatten_foo(self):  # noqa: D102
+  def tree_flatten(self):  # noqa: D102
     return [
         self.divergence,
         self.potentials,
@@ -65,7 +65,7 @@ class SinkhornDivergenceOutput:  # noqa: D101
     }
 
   @classmethod
-  def tree_unflatten_foo(cls, aux_data, children):  # noqa: D102
+  def tree_unflatten(cls, aux_data, children):  # noqa: D102
     div, pots, geoms, a, b = children
     return cls(div, pots, geoms, a=a, b=b, **aux_data)
 

--- a/tests/solvers/quadratic/lower_bound_test.py
+++ b/tests/solvers/quadratic/lower_bound_test.py
@@ -15,7 +15,7 @@
 import jax
 import jax.numpy as jnp
 import pytest
-from ott.geometry import costs, pointcloud
+from ott.geometry import costs, distrib_costs, pointcloud
 from ott.problems.quadratic import quadratic_problem
 from ott.solvers.quadratic import lower_bound
 
@@ -51,8 +51,10 @@ class TestLowerBoundSolver:
     prob = quadratic_problem.QuadraticProblem(
         geom_x, geom_y, a=self.a, b=self.b
     )
-
-    solver = lower_bound.LowerBoundSolver(epsilon=1e-1, cost_fn=cost_fn)
+    distrib_cost = distrib_costs.UnivariateWasserstein(cost_fn=cost_fn)
+    solver = lower_bound.LowerBoundSolver(
+        epsilon=1e-1, distrib_cost=distrib_cost
+    )
 
     out = jax.jit(solver)(prob)
 

--- a/tests/solvers/quadratic/lower_bound_test.py
+++ b/tests/solvers/quadratic/lower_bound_test.py
@@ -39,11 +39,11 @@ class TestLowerBoundSolver:
     self.cy = jax.random.uniform(rngs[3], (self.m, self.m))
 
   @pytest.mark.fast.with_args(
-      "cost_fn",
+      "ground_cost",
       [costs.SqEuclidean(), costs.PNormP(1.5)],
       only_fast=0,
   )
-  def test_lb_pointcloud(self, cost_fn: costs.CostFn):
+  def test_lb_pointcloud(self, ground_cost: costs.TICost):
     x, y = self.x, self.y
 
     geom_x = pointcloud.PointCloud(x)
@@ -51,7 +51,7 @@ class TestLowerBoundSolver:
     prob = quadratic_problem.QuadraticProblem(
         geom_x, geom_y, a=self.a, b=self.b
     )
-    distrib_cost = distrib_costs.UnivariateWasserstein(cost_fn=cost_fn)
+    distrib_cost = distrib_costs.UnivariateWasserstein(ground_cost=ground_cost)
     solver = lower_bound.LowerBoundSolver(
         epsilon=1e-1, distrib_cost=distrib_cost
     )

--- a/tests/solvers/quadratic/lower_bound_test.py
+++ b/tests/solvers/quadratic/lower_bound_test.py
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-from typing import Callable
-
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 from ott.geometry import costs, pointcloud
-from ott.initializers.linear import initializers
 from ott.problems.quadratic import quadratic_problem
-from ott.solvers.linear import implicit_differentiation as implicit_lib
 from ott.solvers.quadratic import lower_bound
-from ott.tools import soft_sort
 
 
 class TestLowerBoundSolver:
@@ -46,18 +39,12 @@ class TestLowerBoundSolver:
     self.cy = jax.random.uniform(rngs[3], (self.m, self.m))
 
   @pytest.mark.fast.with_args(
-      "epsilon_sort,method,cost_fn",
-      [(0.0, "subsample", costs.SqEuclidean()),
-       (1e-1, "quantile", costs.PNormP(1.5)), (1.0, "equal", costs.SqPNorm(1)),
-       (None, "subsample", costs.PNormP(3.1))],
+      "cost_fn",
+      [costs.SqEuclidean(), costs.PNormP(1.5)],
       only_fast=0,
   )
-  def test_lb_pointcloud(
-      self, epsilon_sort: float, method: str, cost_fn: costs.CostFn
-  ):
-    n_sub = min([self.x.shape[0], self.y.shape[0]])
-    x, y = (self.x[:n_sub],
-            self.y[:n_sub]) if method == "equal" else (self.x, self.y)
+  def test_lb_pointcloud(self, cost_fn: costs.CostFn):
+    x, y = self.x, self.y
 
     geom_x = pointcloud.PointCloud(x)
     geom_y = pointcloud.PointCloud(y)
@@ -65,95 +52,8 @@ class TestLowerBoundSolver:
         geom_x, geom_y, a=self.a, b=self.b
     )
 
-    if epsilon_sort is not None and epsilon_sort <= 0.0:
-      sort_fn = None
-    else:
-      sort_fn = functools.partial(
-          soft_sort.sort,
-          epsilon=epsilon_sort,
-          min_iterations=100,
-          max_iterations=100,
-      )
-
-    solver = lower_bound.LowerBoundSolver(
-        epsilon=1e-1,
-        sort_fn=sort_fn,
-        cost_fn=cost_fn,
-        method=method,
-        n_subsamples=4,
-    )
+    solver = lower_bound.LowerBoundSolver(epsilon=1e-1, cost_fn=cost_fn)
 
     out = jax.jit(solver)(prob)
 
-    np.testing.assert_allclose(
-        out.primal_cost, jnp.sum(out.geom.cost_matrix * out.matrix), rtol=1e-3
-    )
-
     assert not jnp.isnan(out.reg_ot_cost)
-
-  @pytest.mark.parametrize("method", ["subsample", "quantile", "equal"])
-  @pytest.mark.parametrize(
-      "sort_fn",
-      [
-          None,
-          functools.partial(
-              soft_sort.sort,
-              epsilon=1e-3,
-              implicit_diff=False,
-              # soft sort uses `sorting` initializer, which uses while loop
-              # which is not reverse-mode diff.
-              initializer=initializers.DefaultInitializer(),
-              min_iterations=10,
-              max_iterations=10,
-          ),
-          functools.partial(
-              soft_sort.sort,
-              epsilon=1e-1,
-              implicit_diff=implicit_lib.ImplicitDiff(),
-              initializer=initializers.DefaultInitializer(),
-              min_iterations=0,
-              max_iterations=100,
-          )
-      ]
-  )
-  def test_lb_grad(
-      self, rng: jax.Array, sort_fn: Callable[[jnp.ndarray], jnp.ndarray],
-      method: str
-  ):
-
-    def fn(x: jnp.ndarray, y: jnp.ndarray) -> float:
-      geom_x = pointcloud.PointCloud(x)
-      geom_y = pointcloud.PointCloud(y)
-      prob = quadratic_problem.QuadraticProblem(geom_x, geom_y)
-
-      solver = lower_bound.LowerBoundSolver(
-          epsilon=5e-2,
-          sort_fn=sort_fn,
-          cost_fn=costs.SqEuclidean(),
-          method=method,
-          n_subsamples=n_sub,
-      )
-      return solver(prob).reg_ot_cost
-
-    rng1, rng2 = jax.random.split(rng)
-    eps, tol = 1e-4, 1e-3
-
-    n_sub = min(self.x.shape[0], self.y.shape[0])
-    if method == "equal":
-      x, y = self.x[:n_sub], self.y[:n_sub]
-    else:
-      x, y = self.x, self.y
-
-    grad_x, grad_y = jax.jit(jax.grad(fn, (0, 1)))(x, y)
-
-    v_x = jax.random.normal(rng1, shape=x.shape)
-    v_x = (v_x / jnp.linalg.norm(v_x, axis=-1, keepdims=True)) * eps
-    expected = fn(x + v_x, y) - fn(x - v_x, y)
-    actual = 2.0 * jnp.vdot(v_x, grad_x)
-    np.testing.assert_allclose(actual, expected, rtol=tol, atol=tol)
-
-    v_y = jax.random.normal(rng2, shape=y.shape)
-    v_y = (v_y / jnp.linalg.norm(v_y, axis=-1, keepdims=True)) * eps
-    expected = (fn(x, y + v_y) - fn(x, y - v_y))
-    actual = 2.0 * jnp.vdot(v_y, grad_y)
-    np.testing.assert_allclose(actual, expected, rtol=tol, atol=tol)


### PR DESCRIPTION
Follow up on @Daniel-Packer 's implementation

- New API for ``UnivariateSolver`` more in agreement with other implementations (takes a problem as input now)
  - In particular, ``UnivariateSolver`` can now take a standard ``prob`` on point clouds of size ``[n,d]``. This means that ``d`` independent slices will be considered, running 1D OT on each of them.
- Implementation for fractional costs ``a`` and ``b`` of all flavors, and simplifications (essentially no need to pass ``method`` string, only arguments such as ``num_subsamples`` or ``quantiles``. If those are passed then user intends to use these alternative methods. Otherwise, select automatically the good method by checking problem's nature (in particular ``n=m`` and weights were uniform (only weaknesses: only checks if those were by default, don't see obvious workaround to test numerically)
- No option to use soft sorting operators. Not completely sure this makes so much sense as of now, so I simplified
- Also Output OT matrix, even for fractional cost, in a new ``UnivariateOutput`` namedtuple. 
- ``UnivariateWasserstein`` is now a new cost for point clouds. This makes sense for ``lower_bound.py`` and slightly alleviates code there, rather than using the double vmap that is considered by default in the ``.pairwise`` method of a ``CostFn``

