### PR TITLE
Potentials as tuple

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,8 @@ jobs:
         include:
         - python-version: '3.9'
           os: macos-latest
+        - python-version: '3.10'
+          os: macos-14
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -10,7 +10,7 @@
     .. autosummary::
         :toctree: .
     {% for item in methods %}
-    {%- if item not in ['__init__', 'tree_flatten', 'tree_unflatten', 'bind', 'tabulate'] %}
+    {%- if item not in ['__init__', 'tree_flatten', 'tree_unflatten', 'bind', 'tabulate', 'module_paths'] %}
         ~{{ name }}.{{ item }}
     {%- endif %}
     {%- endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,8 +104,8 @@ spelling_lang = "en_US"
 spelling_warning = True
 spelling_word_list_filename = ["spelling/technical.txt", "spelling/misc.txt"]
 spelling_add_pypi_package_names = True
-# flax misspelled words; `flax.linen.Module.bind` is ignored in `class.rst`
-# because of indentation error that cannot be suppressed
+# flax misspelled words; `flax.linen.Module.{bind,module_paths}` is ignored in
+# the `class.rst` because of indentation error that cannot be suppressed
 spelling_exclude_patterns = [
     "bibliography.rst",
     "**setup.rst",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,10 @@ markers = [
     "fast: Mark tests as fast.",
 ]
 filterwarnings = [
+    "ignore:\\n*.*scipy.sparse array",
     "ignore:jax.random.KeyArray is deprecated:DeprecationWarning",
+    "ignore:.*jax.config:DeprecationWarning",
+    "ignore:jax.core.Shape is deprecated:DeprecationWarning:chex",
 ]
 
 [tool.coverage.run]

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -284,7 +284,7 @@ class SqEuclidean(TICost):
 
   def pairwise(self, x: jnp.ndarray, y: jnp.ndarray) -> float:
     """Compute minus twice the dot-product between vectors."""
-    return -2. * jnp.vdot(x, y)
+    return -2.0 * jnp.vdot(x, y)
 
   def h(self, z: jnp.ndarray) -> float:  # noqa: D102
     return jnp.sum(z ** 2)

--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -806,7 +806,6 @@ class Bures(CostFn):
     min_iterations = kwargs.pop("min_iterations", 1)
     max_iterations = kwargs.pop("max_iterations", 100)
     inner_iterations = kwargs.pop("inner_iterations", 5)
-    dtype = covs.dtype
 
     @functools.partial(jax.vmap, in_axes=[None, 0, 0])
     def scale_covariances(
@@ -838,10 +837,7 @@ class Bures(CostFn):
 
     def init_state() -> Tuple[jnp.ndarray, float]:
       cov_init = jnp.eye(self._dimension)
-      diffs = -jnp.ones(
-          (np.ceil(max_iterations / inner_iterations).astype(int),),
-          dtype=dtype
-      )
+      diffs = -jnp.ones(math.ceil(max_iterations / inner_iterations))
       return cov_init, diffs
 
     cov, diffs = fixed_point_loop.fixpoint_iter(
@@ -990,7 +986,7 @@ class UnbalancedBures(CostFn):
     diff_means = mean_x - mean_y
 
     # Identity matrix of suitable size
-    iden = jnp.eye(self._dimension, dtype=x.dtype)
+    iden = jnp.eye(self._dimension)
 
     # Creates matrices needed in the computation
     tilde_a = 0.5 * gam * (iden - lam * jnp.linalg.inv(cov_x + lam * iden))

--- a/src/ott/geometry/geodesic.py
+++ b/src/ott/geometry/geodesic.py
@@ -56,7 +56,7 @@ class Geodesic(geometry.Geometry):
       t: float = 1e-3,
       **kwargs: Any
   ):
-    super().__init__(epsilon=1., **kwargs)
+    super().__init__(epsilon=1.0, **kwargs)
     self.scaled_laplacian = scaled_laplacian
     self.eigval = eigval
     self.chebyshev_coeffs = chebyshev_coeffs
@@ -104,7 +104,7 @@ class Geodesic(geometry.Geometry):
     if directed:
       G = G + G.T
     if t is None:
-      t = (jnp.sum(G) / jnp.sum(G > 0.0)) ** 2.0
+      t = (jnp.sum(G) / jnp.sum(G > 0.0)) ** 2
 
     degree = jnp.sum(G, axis=1)
     laplacian = jnp.diag(degree) - G

--- a/src/ott/geometry/geometry.py
+++ b/src/ott/geometry/geometry.py
@@ -740,9 +740,9 @@ class Geometry:
       if arr is None:
         return None
       if src_ixs is not None:
-        arr = arr[jnp.atleast_1d(src_ixs)]
+        arr = arr[src_ixs, ...]
       if tgt_ixs is not None:
-        arr = arr[:, jnp.atleast_1d(tgt_ixs)]
+        arr = arr[:, tgt_ixs]
       return arr  # noqa: RET504
 
     return self._mask_subset_helper(
@@ -877,12 +877,11 @@ class Geometry:
     return arr / jnp.sum(arr)
 
   @staticmethod
-  def _normalize_mask(mask: Optional[Union[int, jnp.ndarray]],
+  def _normalize_mask(mask: Optional[jnp.ndarray],
                       size: int) -> Optional[jnp.ndarray]:
     """Convert array of indices to a boolean mask."""
     if mask is None:
       return None
-    mask = jnp.atleast_1d(mask)
     if not jnp.issubdtype(mask, (bool, jnp.bool_)):
       mask = jnp.isin(jnp.arange(size), mask)
     assert mask.shape == (size,)

--- a/src/ott/geometry/geometry.py
+++ b/src/ott/geometry/geometry.py
@@ -626,7 +626,7 @@ class Geometry:
       rank: int = 0,
       tol: float = 1e-2,
       rng: Optional[jax.Array] = None,
-      scale: float = 1.
+      scale: float = 1.0
   ) -> "low_rank.LRCGeometry":
     r"""Factorize the cost matrix using either SVD (full) or :cite:`indyk:19`.
 
@@ -697,7 +697,7 @@ class Geometry:
       _, d, v = jnp.linalg.svd(U.T @ U)  # (k,), (k, k)
       v = v.T / jnp.sqrt(d)[None, :]
 
-      inv_scale = (1. / jnp.sqrt(n_subset))
+      inv_scale = (1.0 / jnp.sqrt(n_subset))
       col_ixs = jax.random.choice(rng5, m, shape=(n_subset,))  # (n_subset,)
 
       # (n, n_subset)
@@ -757,7 +757,7 @@ class Geometry:
       self,
       src_mask: Optional[jnp.ndarray],
       tgt_mask: Optional[jnp.ndarray],
-      mask_value: float = 0.,
+      mask_value: float = 0.0,
   ) -> "Geometry":
     """Mask rows or columns of a geometry.
 
@@ -855,7 +855,7 @@ class Geometry:
         self._kernel_matrix if self._cost_matrix is None else self._cost_matrix
     ).dtype
 
-  def _masked_geom(self, mask_value: float = 0.) -> "Geometry":
+  def _masked_geom(self, mask_value: float = 0.0) -> "Geometry":
     """Mask geometry based on :attr:`src_mask` and :attr:`tgt_mask`."""
     src_mask, tgt_mask = self.src_mask, self.tgt_mask
     if src_mask is None and tgt_mask is None:

--- a/src/ott/geometry/geometry.py
+++ b/src/ott/geometry/geometry.py
@@ -673,8 +673,8 @@ class Geometry:
       i_star = jax.random.randint(rng1, shape=(), minval=0, maxval=n)
       j_star = jax.random.randint(rng2, shape=(), minval=0, maxval=m)
 
-      ci_star = self.subset(i_star, None).cost_matrix.ravel() ** 2  # (m,)
-      cj_star = self.subset(None, j_star).cost_matrix.ravel() ** 2  # (n,)
+      ci_star = self.subset([i_star], None).cost_matrix.ravel() ** 2  # (m,)
+      cj_star = self.subset(None, [j_star]).cost_matrix.ravel() ** 2  # (n,)
 
       p_row = cj_star + ci_star[j_star] + jnp.mean(ci_star)  # (n,)
       p_row /= jnp.sum(p_row)

--- a/src/ott/geometry/graph.py
+++ b/src/ott/geometry/graph.py
@@ -56,7 +56,7 @@ class Graph(geometry.Geometry):
       tol: float = -1.0,
       **kwargs: Any
   ):
-    super().__init__(epsilon=1., **kwargs)
+    super().__init__(epsilon=1.0, **kwargs)
     self.laplacian = laplacian
     self.t = t
     self.n_steps = n_steps
@@ -107,7 +107,7 @@ class Graph(geometry.Geometry):
       laplacian = inv_sqrt_deg @ laplacian @ inv_sqrt_deg
 
     if t is None:
-      t = (jnp.sum(G) / jnp.sum(G > 0.)) ** 2
+      t = (jnp.sum(G) / jnp.sum(G > 0.0)) ** 2
 
     return cls(laplacian, t=t, **kwargs)
 
@@ -162,7 +162,7 @@ class Graph(geometry.Geometry):
     # axis we can ignore since the matrix is symmetric
     del eps, axis
 
-    force_scan = self.tol < 0.
+    force_scan = self.tol < 0.0
     fixpoint_fn = (
         fixed_point_loop.fixpoint_iter
         if force_scan else fixed_point_loop.fixpoint_iter_backprop
@@ -204,9 +204,9 @@ class Graph(geometry.Geometry):
   def _scale(self) -> float:
     """Constant used to scale the Laplacian."""
     if self.numerical_scheme == "backward_euler":
-      return self.t / (4. * self.n_steps)
+      return self.t / (4.0 * self.n_steps)
     if self.numerical_scheme == "crank_nicolson":
-      return self.t / (2. * self.n_steps)
+      return self.t / (2.0 * self.n_steps)
     raise NotImplementedError(
         f"Numerical scheme `{self.numerical_scheme}` is not implemented."
     )

--- a/src/ott/geometry/grid.py
+++ b/src/ott/geometry/grid.py
@@ -320,7 +320,7 @@ class Grid(geometry.Geometry):
       self,
       src_mask: Optional[jnp.ndarray],
       tgt_mask: Optional[jnp.ndarray],
-      mask_value: float = 0.,
+      mask_value: float = 0.0,
   ) -> NoReturn:
     """Not implemented."""
     raise NotImplementedError("Masking is not implemented for grids.")

--- a/src/ott/geometry/low_rank.py
+++ b/src/ott/geometry/low_rank.py
@@ -251,7 +251,7 @@ class LRCGeometry(geometry.Geometry):
         arr: Optional[jnp.ndarray],
         ixs: Optional[jnp.ndarray],
     ) -> jnp.ndarray:
-      return arr if arr is None or ixs is None else arr[jnp.atleast_1d(ixs)]
+      return arr if arr is None or ixs is None else arr[ixs, ...]
 
     return self._mask_subset_helper(
         src_ixs, tgt_ixs, fn=subset_fn, propagate_mask=True, **kwargs

--- a/src/ott/geometry/low_rank.py
+++ b/src/ott/geometry/low_rank.py
@@ -261,7 +261,7 @@ class LRCGeometry(geometry.Geometry):
       self,
       src_mask: Optional[jnp.ndarray],
       tgt_mask: Optional[jnp.ndarray],
-      mask_value: float = 0.,
+      mask_value: float = 0.0,
   ) -> "LRCGeometry":
 
     def mask_fn(

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -80,13 +80,13 @@ class PointCloud(geometry.Geometry):
   def _norm_x(self) -> Union[float, jnp.ndarray]:
     if self._axis_norm == 0:
       return self.cost_fn.norm(self.x)
-    return 0.
+    return 0.0
 
   @property
   def _norm_y(self) -> Union[float, jnp.ndarray]:
     if self._axis_norm == 0:
       return self.cost_fn.norm(self.y)
-    return 0.
+    return 0.0
 
   @property
   def can_LRC(self):  # noqa: D102
@@ -583,7 +583,7 @@ class PointCloud(geometry.Geometry):
     x = x / jnp.linalg.norm(x, axis=-1, keepdims=True)
     y = y / jnp.linalg.norm(y, axis=-1, keepdims=True)
     # TODO(michalk8): find a better way
-    aux_data["scale_cost"] = 2. / self.inv_scale_cost
+    aux_data["scale_cost"] = 2.0 / self.inv_scale_cost
     cost_fn = costs.SqEuclidean()
     return type(self).tree_unflatten(aux_data, [x, y] + args + [cost_fn])
 
@@ -658,7 +658,7 @@ class PointCloud(geometry.Geometry):
       self,
       src_mask: Optional[jnp.ndarray],
       tgt_mask: Optional[jnp.ndarray],
-      mask_value: float = 0.,
+      mask_value: float = 0.0,
   ) -> "PointCloud":
 
     def mask_fn(

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -648,7 +648,7 @@ class PointCloud(geometry.Geometry):
         arr: Optional[jnp.ndarray],
         ixs: Optional[jnp.ndarray],
     ) -> jnp.ndarray:
-      return arr if arr is None or ixs is None else arr[jnp.atleast_1d(ixs)]
+      return arr if arr is None or ixs is None else arr[ixs, ...]
 
     return self._mask_subset_helper(
         src_ixs, tgt_ixs, fn=subset_fn, propagate_mask=True, **kwargs

--- a/src/ott/initializers/linear/initializers.py
+++ b/src/ott/initializers/linear/initializers.py
@@ -105,8 +105,8 @@ class SinkhornInitializer(abc.ABC):
     ), f"Expected `g_v` to have shape `{m,}`, found `{b.shape}`."
 
     # cancel dual variables for zero weights
-    a = jnp.where(ot_prob.a > 0., a, -jnp.inf if lse_mode else 0.)
-    b = jnp.where(ot_prob.b > 0., b, -jnp.inf if lse_mode else 0.)
+    a = jnp.where(ot_prob.a > 0.0, a, -jnp.inf if lse_mode else 0.0)
+    b = jnp.where(ot_prob.b > 0.0, b, -jnp.inf if lse_mode else 0.0)
 
     return a, b
 

--- a/src/ott/initializers/linear/initializers.py
+++ b/src/ott/initializers/linear/initializers.py
@@ -339,10 +339,10 @@ class SubsampleInitializer(DefaultInitializer):
 
     # subsample
     sub_x = jax.random.choice(
-        key=rng_x, a=x, shape=(self.subsample_n_x,), replace=True, p=a, axis=0
+        rng_x, a=x, shape=(self.subsample_n_x,), replace=True, p=a, axis=0
     )
     sub_y = jax.random.choice(
-        key=rng_y, a=y, shape=(self.subsample_n_y,), replace=True, p=b, axis=0
+        rng_y, a=y, shape=(self.subsample_n_y,), replace=True, p=b, axis=0
     )
 
     # create subsampled point cloud geometry

--- a/src/ott/initializers/linear/initializers_lr.py
+++ b/src/ott/initializers/linear/initializers_lr.py
@@ -262,7 +262,7 @@ class RandomInitializer(LRInitializer):
       **kwargs: Any,
   ) -> jnp.ndarray:
     del kwargs
-    init_g = jnp.abs(jax.random.uniform(rng, (self.rank,))) + 1.
+    init_g = jnp.abs(jax.random.uniform(rng, (self.rank,))) + 1.0
     return init_g / jnp.sum(init_g)
 
 
@@ -300,7 +300,7 @@ class Rank2Initializer(LRInitializer):
     y = (marginal - lambda_1 * x) / (1.0 - lambda_1)
 
     return ((lambda_1 * x[:, None] @ g1.reshape(1, -1)) +
-            ((1 - lambda_1) * y[:, None] @ g2.reshape(1, -1)))
+            ((1.0 - lambda_1) * y[:, None] @ g2.reshape(1, -1)))
 
   def init_q(  # noqa: D102
       self,
@@ -477,7 +477,7 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
   def __init__(
       self,
       rank: int,
-      gamma: float = 10.,
+      gamma: float = 10.0,
       min_iterations: int = 0,
       max_iterations: int = 100,
       inner_iterations: int = 10,
@@ -523,7 +523,7 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
 
     def init_fn() -> GeneralizedKMeansInitializer.State:
       n = geom.shape[0]
-      factor = jnp.abs(jax.random.normal(rng, (n, self.rank))) + 1.  # (n, r)
+      factor = jnp.abs(jax.random.normal(rng, (n, self.rank))) + 1.0  # (n, r)
       factor *= consts.marginal[:, None] / jnp.sum(
           factor, axis=1, keepdims=True
       )
@@ -586,7 +586,7 @@ class GeneralizedKMeansInitializer(KMeansInitializer):
 
       norm = jnp.max(jnp.abs(grad)) ** 2
       gamma = consts.gamma / norm
-      eps = 1. / gamma
+      eps = 1.0 / gamma
 
       cost = grad - eps * mu.safe_log(state.factor)  # (n, r)
       cost = geometry.Geometry(

--- a/src/ott/math/unbalanced_functions.py
+++ b/src/ott/math/unbalanced_functions.py
@@ -75,7 +75,7 @@ def diag_jacobian_of_marginal_fit(
     a vector of the same size as c or h.
   """
   if tau == 1.0:
-    return 0.
+    return 0.0
 
   r = rho(epsilon, tau)
   # here no minus sign because we are taking derivative w.r.t -h
@@ -87,4 +87,4 @@ def diag_jacobian_of_marginal_fit(
 
 
 def rho(epsilon: float, tau: float) -> float:  # noqa: D103
-  return (epsilon * tau) / (1. - tau)
+  return (epsilon * tau) / (1.0 - tau)

--- a/src/ott/math/utils.py
+++ b/src/ott/math/utils.py
@@ -42,7 +42,7 @@ def safe_log(  # noqa: D103
 ) -> jnp.ndarray:
   if eps is None:
     eps = jnp.finfo(x.dtype).tiny
-  return jnp.where(x > 0., jnp.log(x), jnp.log(eps))
+  return jnp.where(x > 0.0, jnp.log(x), jnp.log(eps))
 
 
 @functools.partial(jax.custom_jvp, nondiff_argnums=[1, 2, 3])

--- a/src/ott/neural/solvers/map_estimator.py
+++ b/src/ott/neural/solvers/map_estimator.py
@@ -83,7 +83,7 @@ class MapEstimator:
                                       Tuple[float, Optional[Any]]]] = None,
       regularizer: Optional[Callable[[jnp.ndarray, jnp.ndarray],
                                      Tuple[float, Optional[Any]]]] = None,
-      regularizer_strength: Union[float, Sequence[float]] = 1.,
+      regularizer_strength: Union[float, Sequence[float]] = 1.0,
       num_train_iters: int = 10_000,
       logging: bool = False,
       valid_freq: int = 500,
@@ -136,7 +136,7 @@ class MapEstimator:
     """
     if self._regularizer is not None:
       return self._regularizer
-    return lambda *args, **kwargs: (0., None)
+    return lambda *_, **__: (0.0, None)
 
   @property
   def fitting_loss(self) -> Callable[[jnp.ndarray, jnp.ndarray], float]:
@@ -148,7 +148,7 @@ class MapEstimator:
     """
     if self._fitting_loss is not None:
       return self._fitting_loss
-    return lambda *args, **kwargs: (0., None)
+    return lambda *_, **__: (0.0, None)
 
   @staticmethod
   def _generate_batch(
@@ -212,7 +212,7 @@ class MapEstimator:
         # update the tqdm bar if tqdm is available
         if not isinstance(tbar, range):
           reg_msg = (
-              "NA" if current_logs["eval"]["regularizer"] == 0. else
+              "NA" if current_logs["eval"]["regularizer"] == 0.0 else
               f"{current_logs['eval']['regularizer']:.4f}"
           )
           postfix_str = (

--- a/src/ott/neural/solvers/neuraldual.py
+++ b/src/ott/neural/solvers/neuraldual.py
@@ -589,7 +589,7 @@ class W2NeuralDual:
       # compute Wasserstein-2 distance
       C = jnp.mean(jnp.sum(source ** 2, axis=-1)) + \
           jnp.mean(jnp.sum(target ** 2, axis=-1))
-      W2_dist = C - 2. * (f_source.mean() + f_star_target.mean())
+      W2_dist = C - 2.0 * (f_source.mean() + f_star_target.mean())
 
       return loss, (dual_loss, amor_loss, W2_dist)
 

--- a/src/ott/problems/quadratic/gw_barycenter.py
+++ b/src/ott/problems/quadratic/gw_barycenter.py
@@ -121,7 +121,7 @@ class GWBarycenterProblem(barycenter_problem.FreeBarycenterProblem):
         transport: jnp.ndarray,
         fn: Optional[quadratic_costs.Loss],
     ) -> jnp.ndarray:
-      geom = self._create_y_geometry(y, mask=b > 0.)
+      geom = self._create_y_geometry(y, mask=b > 0.0)
       fn, lin = (None, True) if fn is None else (fn.func, fn.is_linear)
 
       tmp = geom.apply_cost(
@@ -240,8 +240,8 @@ class GWBarycenterProblem(barycenter_problem.FreeBarycenterProblem):
       f: Optional[jnp.ndarray] = None
   ) -> quadratic_problem.QuadraticProblem:
     # TODO(michalk8): in future, mask in the problem for convenience?
-    bary_mask = state.a > 0.
-    y_mask = b > 0.
+    bary_mask = state.a > 0.0
+    y_mask = b > 0.0
 
     geom_xx = self._create_bary_geometry(state.cost, mask=bary_mask)
     geom_yy = self._create_y_geometry(y, mask=y_mask)

--- a/src/ott/solvers/linear/acceleration.py
+++ b/src/ott/solvers/linear/acceleration.py
@@ -106,7 +106,7 @@ class AndersonAcceleration:
     fu = jnp.where(
         trigger_update, fu if lse_mode else geom.scaling_from_potential(fu), fu
     )
-    return state.set(fu=fu, old_fus=old_fus)
+    return state.set(potentials=(fu, state.gv), old_fus=old_fus)
 
   def init_maps(
       self, pb, state: "sinkhorn.SinkhornState"

--- a/src/ott/solvers/linear/continuous_barycenter.py
+++ b/src/ott/solvers/linear/continuous_barycenter.py
@@ -77,8 +77,8 @@ class FreeBarycenterState(NamedTuple):
               pointcloud.PointCloud(
                   x,
                   y,
-                  src_mask=a > 0.,
-                  tgt_mask=b > 0.,
+                  src_mask=a > 0.0,
+                  tgt_mask=b > 0.0,
                   cost_fn=bar_prob.cost_fn,
                   epsilon=bar_prob.epsilon
               ), a, b

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -108,10 +108,10 @@ class SinkhornState(NamedTuple):
     if ot_prob.is_balanced:
       # center the potentials for numerical stability
       is_finite = jnp.isfinite(f)
-      shift = jnp.sum(jnp.where(is_finite, f, 0.)) / jnp.sum(is_finite)
+      shift = jnp.sum(jnp.where(is_finite, f, 0.0)) / jnp.sum(is_finite)
       return f - shift, g + shift
 
-    if ot_prob.tau_a == 1. or ot_prob.tau_b == 1.:
+    if ot_prob.tau_a == 1.0 or ot_prob.tau_b == 1.0:
       # re-centering wasn't done during the lse-step, ignore
       return f, g
 
@@ -890,7 +890,7 @@ class Sinkhorn:
 
     def xi(tau_i: float, tau_j: float) -> float:
       k_ij = k(tau_i, tau_j)
-      return k_ij / (1. - k_ij)
+      return k_ij / (1.0 - k_ij)
 
     def smin(
         potential: jnp.ndarray, marginal: jnp.ndarray, tau: float
@@ -900,7 +900,7 @@ class Sinkhorn:
 
     # only for an unbalanced problems with `tau_{a,b} < 1`
     recenter = (
-        self.recenter_potentials and ot_prob.tau_a < 1. and ot_prob.tau_b < 1.
+        self.recenter_potentials and ot_prob.tau_a < 1.0 and ot_prob.tau_b < 1.0
     )
     w = self.momentum.weight(state, iteration)
     tau_a, tau_b = ot_prob.tau_a, ot_prob.tau_b

--- a/src/ott/solvers/linear/sinkhorn_lr.py
+++ b/src/ott/solvers/linear/sinkhorn_lr.py
@@ -263,7 +263,7 @@ class LRSinkhornOutput(NamedTuple):
 
   @property
   def _inv_g(self) -> jnp.ndarray:
-    return 1. / self.g
+    return 1.0 / self.g
 
 
 @jax.tree_util.register_pytree_node_class
@@ -307,7 +307,7 @@ class LRSinkhorn(sinkhorn.Sinkhorn):
   def __init__(
       self,
       rank: int,
-      gamma: float = 10.,
+      gamma: float = 10.0,
       gamma_rescale: bool = True,
       epsilon: float = 0.0,
       initializer: Union[Literal["random", "rank2", "k-means",
@@ -477,9 +477,9 @@ class LRSinkhorn(sinkhorn.Sinkhorn):
       g_r = _softm(f2, g2_old, c_r, axis=0)
 
       # Second Projection
-      h = (1. / 3.) * (h_old + w_gp + w_q + w_r)
-      h += g_q / (3. * gamma)
-      h += g_r / (3. * gamma)
+      h = (1.0 / 3.0) * (h_old + w_gp + w_q + w_r)
+      h += g_q / (3.0 * gamma)
+      h += g_r / (3.0 * gamma)
       g1 = h + g1_old - g_q / gamma
       g2 = h + g2_old - g_r / gamma
 

--- a/src/ott/solvers/quadratic/gromov_wasserstein_lr.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein_lr.py
@@ -497,9 +497,9 @@ class LRGromovWasserstein(sinkhorn.Sinkhorn):
       g_r = _softm(f2, g2_old, c_r, axis=0)
 
       # Second Projection
-      h = (1. / 3.) * (h_old + w_gp + w_q + w_r)
-      h += g_q / (3. * gamma)
-      h += g_r / (3. * gamma)
+      h = (1.0 / 3.0) * (h_old + w_gp + w_q + w_r)
+      h += g_q / (3.0 * gamma)
+      h += g_r / (3.0 * gamma)
       g1 = h + g1_old - g_q / gamma
       g2 = h + g2_old - g_r / gamma
 

--- a/src/ott/tools/gaussian_mixture/fit_gmm.py
+++ b/src/ott/tools/gaussian_mixture/fit_gmm.py
@@ -151,7 +151,7 @@ def fit_model_em(
     A GMM with updated parameters.
   """
   if point_weights is None:
-    point_weights = jnp.ones(points.shape[:-1], dtype=points.dtype)
+    point_weights = jnp.ones(points.shape[:-1])
   loss_fn = log_prob_loss
   get_q_fn = get_q
   e_step_fn = get_assignment_probs
@@ -211,7 +211,7 @@ def _get_locs(
   n_points = points.shape[0]
   weights = jnp.ones(n_points) / n_points
   rng, subrng = jax.random.split(rng)
-  index = jax.random.choice(key=subrng, a=points.shape[0], p=weights)
+  index = jax.random.choice(subrng, a=points.shape[0], p=weights)
   loc = points[index]
   points = jnp.concatenate([points[:index], points[index + 1:]], axis=0)
 
@@ -221,7 +221,7 @@ def _get_locs(
     min_dist_sq = jnp.min(dist_sq, axis=-1)
     weights = min_dist_sq / jnp.sum(min_dist_sq)
     rng, subrng = jax.random.split(rng)
-    index = jax.random.choice(key=subrng, a=points.shape[0], p=weights)
+    index = jax.random.choice(subrng, a=points.shape[0], p=weights)
     loc = points[index]
     points = jnp.concatenate([points[:index], points[index + 1:]], axis=0)
     locs = jnp.concatenate([locs, loc[None]], axis=0)

--- a/src/ott/tools/gaussian_mixture/fit_gmm.py
+++ b/src/ott/tools/gaussian_mixture/fit_gmm.py
@@ -188,7 +188,7 @@ def _get_dist_sq(points: jnp.ndarray, loc: jnp.ndarray) -> jnp.ndarray:
   """Get the squared distance from each point to each loc."""
 
   def _dist_sq_one_loc(points: jnp.ndarray, loc: jnp.ndarray) -> jnp.ndarray:
-    return jnp.sum((points - loc[None]) ** 2., axis=-1)
+    return jnp.sum((points - loc[None]) ** 2, axis=-1)
 
   dist_sq_fn = jax.vmap(_dist_sq_one_loc, in_axes=(None, 0), out_axes=1)
   return dist_sq_fn(points, loc)

--- a/src/ott/tools/gaussian_mixture/gaussian.py
+++ b/src/ott/tools/gaussian_mixture/gaussian.py
@@ -68,7 +68,6 @@ class Gaussian:
       stdev_mean: float = 0.1,
       stdev_cov: float = 0.1,
       ridge: Union[float, jnp.ndarray] = 0,
-      dtype: Optional[jnp.dtype] = None
   ) -> "Gaussian":
     """Construct a random Gaussian.
 
@@ -79,17 +78,14 @@ class Gaussian:
         (means for both are 0)
       stdev_cov: standard deviated of the covariance
       ridge: Offset for means.
-      dtype: data type
 
     Returns:
       A random Gaussian.
     """
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    loc = jax.random.normal(
-        key=subrng0, shape=(n_dimensions,), dtype=dtype
-    ) * stdev_mean + ridge
+    loc = jax.random.normal(subrng0, shape=(n_dimensions,)) * stdev_mean + ridge
     scale = scale_tril.ScaleTriL.from_random(
-        rng=subrng1, n_dimensions=n_dimensions, stdev=stdev_cov, dtype=dtype
+        subrng1, n_dimensions=n_dimensions, stdev=stdev_cov
     )
     return cls(loc=loc, scale=scale)
 
@@ -140,7 +136,7 @@ class Gaussian:
 
   def sample(self, rng: jax.Array, size: int) -> jnp.ndarray:
     """Generate samples from the distribution."""
-    std_samples_t = jax.random.normal(key=rng, shape=(self.n_dimensions, size))
+    std_samples_t = jax.random.normal(rng, shape=(self.n_dimensions, size))
     return self.loc[None] + (
         jnp.swapaxes(
             jnp.matmul(self.scale.cholesky(), std_samples_t),

--- a/src/ott/tools/gaussian_mixture/gaussian.py
+++ b/src/ott/tools/gaussian_mixture/gaussian.py
@@ -21,7 +21,7 @@ from ott.tools.gaussian_mixture import scale_tril
 
 __all__ = ["Gaussian"]
 
-LOG2PI = math.log(2. * math.pi)
+LOG2PI = math.log(2.0 * math.pi)
 
 
 @jax.tree_util.register_pytree_node_class
@@ -131,7 +131,7 @@ class Gaussian:
     z = self.to_z(x)
     log_det = self.scale.log_det_covariance()
     return (
-        -0.5 * (d * LOG2PI + log_det[None] + jnp.sum(z ** 2., axis=-1))
+        -0.5 * (d * LOG2PI + log_det[None] + jnp.sum(z ** 2, axis=-1))
     )  # (?, k)
 
   def sample(self, rng: jax.Array, size: int) -> jnp.ndarray:
@@ -159,7 +159,7 @@ class Gaussian:
     Returns:
       The :math:`W_2^2` distance between self and other
     """
-    delta_mean = jnp.sum((self.loc - other.loc) ** 2., axis=-1)
+    delta_mean = jnp.sum((self.loc - other.loc) ** 2, axis=-1)
     delta_sigma = self.scale.w2_dist(other.scale)
     return delta_mean + delta_sigma
 

--- a/src/ott/tools/gaussian_mixture/gaussian_mixture_pair.py
+++ b/src/ott/tools/gaussian_mixture/gaussian_mixture_pair.py
@@ -51,8 +51,8 @@ class GaussianMixturePair:
       self,
       gmm0: gaussian_mixture.GaussianMixture,
       gmm1: gaussian_mixture.GaussianMixture,
-      epsilon: float = 1.e-2,
-      tau: float = 1.,
+      epsilon: float = 1e-2,
+      tau: float = 1.0,
       lock_gmm1: bool = False,
   ):
     """Constructor.
@@ -104,7 +104,7 @@ class GaussianMixturePair:
 
   @property
   def rho(self):  # noqa: D102
-    return self.epsilon * self.tau / (1. - self.tau)
+    return self.epsilon * self.tau / (1.0 - self.tau)
 
   @property
   def lock_gmm1(self):  # noqa: D102

--- a/src/ott/tools/gaussian_mixture/linalg.py
+++ b/src/ott/tools/gaussian_mixture/linalg.py
@@ -31,7 +31,7 @@ def get_mean_and_var(
   centered = points - mean[None, :]  # (n, d) - (1, d)
   var = (
       # matmul((1, n), (n, d)) -> (1, d)
-      jnp.matmul(weights, centered ** 2.) / weights_sum
+      jnp.matmul(weights, centered ** 2) / weights_sum
   )
   return mean, var
 

--- a/src/ott/tools/gaussian_mixture/linalg.py
+++ b/src/ott/tools/gaussian_mixture/linalg.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Iterable, List, Optional, Tuple
+from typing import Callable, Iterable, List, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -71,7 +71,7 @@ def flat_to_tril(x: jnp.ndarray, size: int) -> jnp.ndarray:
   Returns:
     Lower triangular matrices.
   """
-  m = jnp.zeros(tuple(list(x.shape[:-1]) + [size, size]), dtype=x.dtype)
+  m = jnp.zeros(x.shape[:-1] + (size, size))
   tril = jnp.tril_indices(size)
   return m.at[..., tril[0], tril[1]].set(x)
 
@@ -96,7 +96,7 @@ def apply_to_diag(
   """Apply a function to the diagonal of a matrix."""
   size = m.shape[-1]
   diag = jnp.diagonal(m, axis1=-2, axis2=-1)
-  ind = jnp.arange(size, dtype=jnp.int32)
+  ind = jnp.arange(size)
   return m.at[..., ind, ind].set(fn(diag))
 
 
@@ -131,10 +131,8 @@ def invmatvectril(
   )
 
 
-def get_random_orthogonal(
-    rng: jax.Array, dim: int, dtype: Optional[jnp.dtype] = None
-) -> jnp.ndarray:
+def get_random_orthogonal(rng: jax.Array, dim: int) -> jnp.ndarray:
   """Get a random orthogonal matrix with the specified dimension."""
-  m = jax.random.normal(key=rng, shape=[dim, dim], dtype=dtype)
+  m = jax.random.normal(rng, shape=[dim, dim])
   q, _ = jnp.linalg.qr(m)
   return q

--- a/src/ott/tools/gaussian_mixture/probabilities.py
+++ b/src/ott/tools/gaussian_mixture/probabilities.py
@@ -38,13 +38,9 @@ class Probabilities:
       rng: jax.Array,
       n_dimensions: int,
       stdev: Optional[float] = 0.1,
-      dtype: Optional[jnp.dtype] = None
   ) -> "Probabilities":
     """Construct a random Probabilities."""
-    return cls(
-        params=jax.random
-        .normal(key=rng, shape=(n_dimensions - 1,), dtype=dtype) * stdev
-    )
+    return cls(params=jax.random.normal(rng, shape=(n_dimensions - 1,)) * stdev)
 
   @classmethod
   def from_probs(cls, probs: jnp.ndarray) -> "Probabilities":
@@ -64,9 +60,7 @@ class Probabilities:
 
   def unnormalized_log_probs(self) -> jnp.ndarray:
     """Get the unnormalized log probabilities."""
-    return jnp.concatenate([self._params,
-                            jnp.zeros((1,), dtype=self.dtype)],
-                           axis=-1)
+    return jnp.concatenate([self._params, jnp.zeros((1,))], axis=-1)
 
   def log_probs(self) -> jnp.ndarray:
     """Get the log probabilities."""
@@ -79,7 +73,7 @@ class Probabilities:
   def sample(self, rng: jax.Array, size: int) -> jnp.ndarray:
     """Sample from the distribution."""
     return jax.random.categorical(
-        key=rng, logits=self.unnormalized_log_probs(), shape=(size,)
+        rng, logits=self.unnormalized_log_probs(), shape=(size,)
     )
 
   def tree_flatten(self):  # noqa: D102

--- a/src/ott/tools/gaussian_mixture/scale_tril.py
+++ b/src/ott/tools/gaussian_mixture/scale_tril.py
@@ -47,7 +47,6 @@ class ScaleTriL:
       rng: jax.Array,
       n_dimensions: int,
       stdev: Optional[float] = 0.1,
-      dtype: jnp.dtype = jnp.float32,
   ) -> "ScaleTriL":
     """Construct a random ScaleTriL.
 
@@ -55,19 +54,16 @@ class ScaleTriL:
       rng: pseudo-random number generator key
       n_dimensions: number of dimensions
       stdev: desired standard deviation (around 0) for the log eigenvalues
-      dtype: data type for the covariance matrix
 
     Returns:
       A ScaleTriL.
     """
     # generate a random orthogonal matrix
     rng, subrng = jax.random.split(rng)
-    q = linalg.get_random_orthogonal(rng=subrng, dim=n_dimensions, dtype=dtype)
+    q = linalg.get_random_orthogonal(subrng, dim=n_dimensions)
 
     # generate random eigenvalues
-    eigs = stdev * jnp.exp(
-        jax.random.normal(key=rng, shape=(n_dimensions,), dtype=dtype)
-    )
+    eigs = stdev * jnp.exp(jax.random.normal(rng, shape=(n_dimensions,)))
 
     # random positive definite matrix
     sigma = q * jnp.expand_dims(eigs, -2) @ q.T

--- a/src/ott/tools/gaussian_mixture/scale_tril.py
+++ b/src/ott/tools/gaussian_mixture/scale_tril.py
@@ -123,7 +123,7 @@ class ScaleTriL:
   def log_det_covariance(self) -> jnp.ndarray:
     """Get the log of the determinant of the covariance matrix."""
     diag = jnp.diagonal(self.cholesky(), axis1=-2, axis2=-1)
-    return 2. * jnp.sum(jnp.log(diag), axis=-1)
+    return 2.0 * jnp.sum(jnp.log(diag), axis=-1)
 
   def centered_to_z(self, x_centered: jnp.ndarray) -> jnp.ndarray:
     """Map centered points to standardized centered points (i.e. cov(z) = I)."""

--- a/src/ott/tools/k_means.py
+++ b/src/ott/tools/k_means.py
@@ -181,7 +181,7 @@ def _reallocate_centroids(
     centroid: jnp.ndarray,
     weight: jnp.ndarray,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-  is_empty = weight <= 0.
+  is_empty = weight <= 0.0
   new_centroid = (1 - is_empty) * centroid + is_empty * const.x[ix]  # (ndim,)
   centroid_to_remove = is_empty * const.weighted_x[ix]  # (ndim,)
   weight_to_remove = is_empty * const.weights[ix]  # (1,)
@@ -219,7 +219,7 @@ def _update_centroids(
   centroids -= to_remove[:, :-1]
   ws -= to_remove[:, -1:]
 
-  return centroids * jnp.where(ws > 0., 1. / ws, 1.)
+  return centroids * jnp.where(ws > 0.0, 1.0 / ws, 1.0)
 
 
 @functools.partial(jax.vmap, in_axes=[0] + [None] * 9)
@@ -266,9 +266,9 @@ def _k_means(
     #   KeyError: dtype([('float0', 'V')])
     # E   The stack trace below excludes JAX-internal frames.
     # E   The preceding is the original exception that occurred, unmodified.
-    prev_assignment = jnp.full((n,), -2.)
-    assignment = jnp.full((n,), -1.)
-    errors = jnp.full((max_iterations,), -1.)
+    prev_assignment = jnp.full((n,), -2.0)
+    assignment = jnp.full((n,), -1.0)
+    errors = jnp.full((max_iterations,), -1.0)
 
     return KMeansState(
         centroids=centroids,

--- a/src/ott/tools/k_means.py
+++ b/src/ott/tools/k_means.py
@@ -127,7 +127,7 @@ def _k_means_plus_plus(
     rng, next_rng = jax.random.split(rng, 2)
     ix = jax.random.choice(rng, jnp.arange(geom.shape[0]), shape=())
     centroids = jnp.full((k, geom.cost_rank), jnp.inf).at[0].set(geom.x[ix])
-    dists = geom.subset(ix, None).cost_matrix[0]
+    dists = geom.subset([ix], None).cost_matrix[0]
     return KPPState(rng=next_rng, centroids=centroids, centroid_dists=dists)
 
   def body_fn(

--- a/src/ott/tools/segment_sinkhorn.py
+++ b/src/ott/tools/segment_sinkhorn.py
@@ -109,8 +109,8 @@ def segment_sinkhorn(
       padded_weight_x: jnp.ndarray,
       padded_weight_y: jnp.ndarray,
   ) -> float:
-    mask_x = padded_weight_x > 0.
-    mask_y = padded_weight_y > 0.
+    mask_x = padded_weight_x > 0.0
+    mask_y = padded_weight_y > 0.0
 
     geom = pointcloud.PointCloud(
         padded_x,

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -193,6 +193,7 @@ def _sinkhorn_divergence(
     # Create dummy output, corresponds to scenario where static_b is True.
     # This choice ensures that `converged`` of this dummy output is True.
     out_yy = sinkhorn.SinkhornOutput(
+        (None, None),
         errors=jnp.array([-jnp.inf]),
         reg_ot_cost=0.0,
         threshold=0.0,

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -319,8 +319,8 @@ def segment_sinkhorn_divergence(
       padded_weight_x: jnp.ndarray,
       padded_weight_y: jnp.ndarray,
   ) -> float:
-    mask_x = padded_weight_x > 0.
-    mask_y = padded_weight_y > 0.
+    mask_x = padded_weight_x > 0.0
+    mask_y = padded_weight_y > 0.0
     return sinkhorn_divergence(
         pointcloud.PointCloud,
         padded_x,

--- a/src/ott/tools/soft_sort.py
+++ b/src/ott/tools/soft_sort.py
@@ -415,7 +415,7 @@ def quantile(
       safe_weight = jnp.concatenate([
           safe_weight,
           jnp.array(
-              [.02]
+              [0.02]
           ),  # reasonable mass per quantile for a small number of points
           jnp.array(
               [1.5 / num_points]

--- a/src/ott/tools/soft_sort.py
+++ b/src/ott/tools/soft_sort.py
@@ -129,7 +129,7 @@ def _sort(
     start_index = 1
     b = jnp.concatenate([
         jnp.array([(num_points - topk) / num_points]),
-        jnp.ones(topk, dtype=inputs.dtype) / num_points
+        jnp.ones(topk) / num_points
     ])
   else:
     # Use the "sorting" initializer if default uniform weights of same size.
@@ -636,12 +636,12 @@ def sort_with(
     An Array of size [batch | topk, dim].
   """
   num_points = criterion.shape[0]
-  weights = jnp.ones(num_points, dtype=criterion.dtype) / num_points
+  weights = jnp.ones(num_points) / num_points
   if 0 < topk < num_points:
     start_index = 1
     target_weights = jnp.concatenate([
         jnp.array([(num_points - topk) / num_points]),
-        jnp.ones(topk, dtype=inputs.dtype) / num_points
+        jnp.ones(topk) / num_points
     ])
   else:
     start_index = 0

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -40,7 +40,7 @@ IOCallback_t = Callable[[Status_t], None]
 def register_pytree_node(cls: type) -> type:
   """Register dataclasses as pytree_nodes."""
   cls = dataclasses.dataclass()(cls)
-  flatten = lambda obj: jax.tree_flatten(dataclasses.asdict(obj))
+  flatten = lambda obj: jax.tree_util.tree_flatten(dataclasses.asdict(obj))
   unflatten = lambda d, children: cls(**d.unflatten(children))
   jax.tree_util.register_pytree_node(cls, flatten, unflatten)
   return cls

--- a/tests/geometry/costs_test.py
+++ b/tests/geometry/costs_test.py
@@ -90,7 +90,7 @@ class TestBuresBarycenter:
     s = jnp.array([3.3075, 0.8545, 0.1110])
     Sigma2 = s * jnp.eye(d)
     # initializing Bures cost function
-    weights = jnp.array([.3, .7])
+    weights = jnp.array([0.3, 0.7])
     tolerance = 1e-6
     min_iterations = 2
     inner_iterations = 1

--- a/tests/geometry/geodesic_test.py
+++ b/tests/geometry/geodesic_test.py
@@ -131,7 +131,7 @@ class TestGeodesic:
   def test_approximates_ground_truth(self, t: Optional[float], order: int):
     tol = 1e-2
     G = nx.linalg.adjacency_matrix(balanced_tree(r=2, h=5))
-    G = jnp.asarray(G.toarray())
+    G = jnp.asarray(G.toarray().astype(float))
     eye = jnp.eye(G.shape[0])
     eps = jnp.finfo(eye.dtype).tiny
 

--- a/tests/geometry/geodesic_test.py
+++ b/tests/geometry/geodesic_test.py
@@ -68,7 +68,7 @@ def gt_geometry(
 
   cost = jnp.asarray(cost)
   kernel = jnp.asarray(np.exp(-cost / epsilon))
-  return geometry.Geometry(cost_matrix=cost, kernel_matrix=kernel, epsilon=1.)
+  return geometry.Geometry(cost_matrix=cost, kernel_matrix=kernel, epsilon=1.0)
 
 
 def exact_heat_kernel(G: jnp.ndarray, normalize: bool = False, t: float = 10):
@@ -241,14 +241,14 @@ class TestGeodesic:
 
     eps = 1e-3
     G = random_graph(20, p=0.5)
-    geom = geodesic.Geodesic.from_graph(G, t=1.)
+    geom = geodesic.Geodesic.from_graph(G, t=1.0)
 
     v_w = jax.random.normal(rng, shape=G.shape)
     v_w = (v_w / jnp.linalg.norm(v_w, axis=-1, keepdims=True)) * eps
 
     grad_sl = jax.grad(callback)(geom).scaled_laplacian
-    geom__finite_right = geodesic.Geodesic.from_graph(G + v_w, t=1.)
-    geom__finite_left = geodesic.Geodesic.from_graph(G - v_w, t=1.)
+    geom__finite_right = geodesic.Geodesic.from_graph(G + v_w, t=1.0)
+    geom__finite_left = geodesic.Geodesic.from_graph(G - v_w, t=1.0)
 
     expected = callback(geom__finite_right) - callback(geom__finite_left)
     actual = 2 * jnp.vdot(v_w, grad_sl)

--- a/tests/geometry/geodesic_test.py
+++ b/tests/geometry/geodesic_test.py
@@ -131,7 +131,7 @@ class TestGeodesic:
   def test_approximates_ground_truth(self, t: Optional[float], order: int):
     tol = 1e-2
     G = nx.linalg.adjacency_matrix(balanced_tree(r=2, h=5))
-    G = jnp.asarray(G.toarray(), dtype=float)
+    G = jnp.asarray(G.toarray())
     eye = jnp.eye(G.shape[0])
     eps = jnp.finfo(eye.dtype).tiny
 

--- a/tests/geometry/graph_test.py
+++ b/tests/geometry/graph_test.py
@@ -142,7 +142,7 @@ class TestGraph:
   def test_crank_nicolson_more_stable(self, t: Optional[float], n_steps: int):
     tol = 5 * t
     G = nx.linalg.adjacency_matrix(balanced_tree(r=2, h=5))
-    G = jnp.asarray(G.toarray(), dtype=float)
+    G = jnp.asarray(G.toarray())
     eye = jnp.eye(G.shape[0])
 
     be_geom = graph.Graph.from_graph(

--- a/tests/geometry/graph_test.py
+++ b/tests/geometry/graph_test.py
@@ -70,7 +70,7 @@ def gt_geometry(
 
   cost = jnp.asarray(cost)
   kernel = jnp.asarray(np.exp(-cost / epsilon))
-  return geometry.Geometry(cost_matrix=cost, kernel_matrix=kernel, epsilon=1.)
+  return geometry.Geometry(cost_matrix=cost, kernel_matrix=kernel, epsilon=1.0)
 
 
 class TestGraph:
@@ -90,7 +90,7 @@ class TestGraph:
     # we symmetrize the kernel explicitly when materializing it, because
     # numerical error arise  for small `t` and `backward_euler`
     np.testing.assert_array_equal(kernel, kernel.T)
-    np.testing.assert_array_equal(jnp.linalg.eigvals(kernel) > 0., True)
+    np.testing.assert_array_equal(jnp.linalg.eigvals(kernel) > 0.0, True)
     # internally, the axis is ignored because the kernel is symmetric
     np.testing.assert_array_equal(vec0, vec1)
     np.testing.assert_array_equal(vec_direct0, vec_direct1)
@@ -102,7 +102,7 @@ class TestGraph:
     G = random_graph(38, return_laplacian=False)
     geom = graph.Graph.from_graph(G, t=None)
 
-    expected = (jnp.sum(G) / jnp.sum(G > 0.)) ** 2
+    expected = (jnp.sum(G) / jnp.sum(G > 0.0)) ** 2
     actual = geom.t
     np.testing.assert_equal(actual, expected)
 
@@ -258,7 +258,7 @@ class TestGraph:
     ) -> float:
       G = sparse.BCOO((data, jnp.c_[rows, cols]), shape=shape).todense()
 
-      geom = graph.Graph.from_graph(G, t=1.)
+      geom = graph.Graph.from_graph(G, t=1.0)
       solver = sinkhorn.Sinkhorn(lse_mode=False, **kwargs)
       problem = linear_problem.LinearProblem(geom)
 

--- a/tests/geometry/lr_cost_test.py
+++ b/tests/geometry/lr_cost_test.py
@@ -42,7 +42,9 @@ class TestLRGeometry:
             rtol=1e-4
         )
 
-  @pytest.mark.parametrize("scale_cost", ["mean", "max_cost", "max_bound", 42.])
+  @pytest.mark.parametrize(
+      "scale_cost", ["mean", "max_cost", "max_bound", 42.0]
+  )
   def test_conversion_pointcloud(
       self, rng: jax.Array, scale_cost: Union[str, float]
   ):
@@ -139,19 +141,19 @@ class TestLRGeometry:
     rng1, rng2 = jax.random.split(rng, 2)
 
     geom1 = pointcloud.PointCloud(
-        jax.random.normal(rng1, (n, d)) + 10.,
+        jax.random.normal(rng1, (n, d)) + 10.0,
         epsilon=epsilon,
         scale_cost=scale_cost
     )
     geom2 = pointcloud.PointCloud(
-        jax.random.normal(rng2, (n, d)) + 20.,
+        jax.random.normal(rng2, (n, d)) + 20.0,
         epsilon=epsilon,
         scale_cost=scale_cost
     )
     geom_lr = geom1.to_LRCGeometry(scale=1 - scale) + \
         geom2.to_LRCGeometry(scale=scale)
 
-    expected = (1 - scale) * geom1.cost_matrix + scale * geom2.cost_matrix
+    expected = (1.0 - scale) * geom1.cost_matrix + scale * geom2.cost_matrix
     actual = geom_lr.cost_matrix
 
     np.testing.assert_allclose(actual, expected, rtol=1e-3, atol=1e-3)

--- a/tests/geometry/lr_cost_test.py
+++ b/tests/geometry/lr_cost_test.py
@@ -285,7 +285,7 @@ class TestCostMatrixFactorization:
     geom = low_rank.LRCGeometry(cost_1=x, cost_2=x + 1)
     res = geom.apply_transport_from_potentials(f=f, g=g, vec=vec)
 
-    np.testing.assert_allclose(res, 1.1253539e-07, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(res, 1.1253539e-7, rtol=1e-6, atol=1e-6)
 
   @pytest.mark.limit_memory("190 MB")
   def test_large_scale_factorization(self, rng: jax.Array):

--- a/tests/geometry/pointcloud_test.py
+++ b/tests/geometry/pointcloud_test.py
@@ -42,10 +42,10 @@ class TestPointCloudApply:
     geom = geometry.Geometry(cost)
     prod0_geom = geom.apply_cost(vec0, axis=0)
     prod1_geom = geom.apply_cost(vec1, axis=1)
-    np.testing.assert_allclose(prod0_online, prod0, rtol=1e-03, atol=1e-02)
-    np.testing.assert_allclose(prod1_online, prod1, rtol=1e-03, atol=1e-02)
-    np.testing.assert_allclose(prod0_geom, prod0, rtol=1e-03, atol=1e-02)
-    np.testing.assert_allclose(prod1_geom, prod1, rtol=1e-03, atol=1e-02)
+    np.testing.assert_allclose(prod0_online, prod0, rtol=1e-3, atol=1e-2)
+    np.testing.assert_allclose(prod1_online, prod1, rtol=1e-3, atol=1e-2)
+    np.testing.assert_allclose(prod0_geom, prod0, rtol=1e-3, atol=1e-2)
+    np.testing.assert_allclose(prod1_geom, prod1, rtol=1e-3, atol=1e-2)
 
     geom = pointcloud.PointCloud(x, y, cost_fn=costs.Euclidean(), batch_size=4)
     prod0_online = geom.apply_cost(vec0, axis=0)
@@ -55,8 +55,8 @@ class TestPointCloudApply:
     )
     prod0 = geom.apply_cost(vec0, axis=0)
     prod1 = geom.apply_cost(vec1, axis=1)
-    np.testing.assert_allclose(prod0_online, prod0, rtol=1e-03, atol=1e-02)
-    np.testing.assert_allclose(prod1_online, prod1, rtol=1e-03, atol=1e-02)
+    np.testing.assert_allclose(prod0_online, prod0, rtol=1e-3, atol=1e-2)
+    np.testing.assert_allclose(prod1_online, prod1, rtol=1e-3, atol=1e-2)
 
     geom = pointcloud.PointCloud(x, y, batch_size=5)
     prod0_online = geom.apply_kernel(vec0, axis=0)
@@ -64,8 +64,8 @@ class TestPointCloudApply:
     geom = pointcloud.PointCloud(x, y, batch_size=None)
     prod0 = geom.apply_kernel(vec0, axis=0)
     prod1 = geom.apply_kernel(vec1, axis=1)
-    np.testing.assert_allclose(prod0_online, prod0, rtol=1e-03, atol=1e-02)
-    np.testing.assert_allclose(prod1_online, prod1, rtol=1e-03, atol=1e-02)
+    np.testing.assert_allclose(prod0_online, prod0, rtol=1e-3, atol=1e-2)
+    np.testing.assert_allclose(prod1_online, prod1, rtol=1e-3, atol=1e-2)
 
   def test_general_cost_fn(self, rng: jax.Array):
     """Test non-vec cost apply to vec."""
@@ -85,8 +85,8 @@ class TestPointCloudApply:
     prod0_geom = geom.apply_cost(vec0, axis=0)
     prod1_geom = geom.apply_cost(vec1, axis=1)
 
-    np.testing.assert_allclose(prod0_geom, prod0, rtol=1e-03, atol=1e-02)
-    np.testing.assert_allclose(prod1_geom, prod1, rtol=1e-03, atol=1e-02)
+    np.testing.assert_allclose(prod0_geom, prod0, rtol=1e-3, atol=1e-2)
+    np.testing.assert_allclose(prod1_geom, prod1, rtol=1e-3, atol=1e-2)
 
   def test_correct_shape(self):
     n, m, d = 11, 12, 17

--- a/tests/geometry/pointcloud_test.py
+++ b/tests/geometry/pointcloud_test.py
@@ -134,7 +134,7 @@ class TestPointCloudCosineConversion:
     assert eucl.is_squared_euclidean
 
     np.testing.assert_allclose(
-        2. * eucl.inv_scale_cost, cosine.inv_scale_cost, rtol=1e-6, atol=1e-6
+        2.0 * eucl.inv_scale_cost, cosine.inv_scale_cost, rtol=1e-6, atol=1e-6
     )
     np.testing.assert_allclose(
         eucl.mean_cost_matrix, cosine.mean_cost_matrix, rtol=1e-6, atol=1e-6

--- a/tests/geometry/scaling_cost_test.py
+++ b/tests/geometry/scaling_cost_test.py
@@ -42,7 +42,7 @@ class TestScaleCost:
     self.eps = 5e-2
 
   @pytest.mark.fast.with_args(
-      scale=["median", "mean", "max_cost", "max_norm", "max_bound", 100.],
+      scale=["median", "mean", "max_cost", "max_norm", "max_bound", 100.0],
       batch_size=[None, 4],
       only_fast=[0, -3],
   )
@@ -88,7 +88,7 @@ class TestScaleCost:
     )
 
   @pytest.mark.parametrize(
-      "scale", ["mean", "max_cost", "max_norm", "max_bound", 100.]
+      "scale", ["mean", "max_cost", "max_norm", "max_bound", 100.0]
   )
   def test_online_matches_offline_pointcloud(self, scale: Union[str, float]):
     """Tests that the scale factors for online matches the ones without."""
@@ -113,7 +113,7 @@ class TestScaleCost:
       np.testing.assert_allclose(1.0, geom1.cost_matrix.max(), rtol=1e-4)
 
   @pytest.mark.fast.with_args(
-      "scale", ["median", "mean", "max_cost", 100.], only_fast=1
+      "scale", ["median", "mean", "max_cost", 100.0], only_fast=1
   )
   def test_scale_cost_geometry(self, scale: Union[str, float]):
     """Test various scale cost options for geometry."""
@@ -150,7 +150,7 @@ class TestScaleCost:
     )
 
   @pytest.mark.fast.with_args(
-      "scale", ["mean", "max_bound", "max_cost", 100.], only_fast=2
+      "scale", ["mean", "max_bound", "max_cost", 100.0], only_fast=2
   )
   def test_scale_cost_low_rank(self, scale: Union[str, float]):
     """Test various scale cost options for low rank."""

--- a/tests/geometry/subsetting_test.py
+++ b/tests/geometry/subsetting_test.py
@@ -59,7 +59,7 @@ def geom_masked(request, pc_masked) -> Tuple[Geom_t, pointcloud.PointCloud]:
 @pytest.mark.fast()
 class TestMaskPointCloud:
 
-  @pytest.mark.parametrize("tgt_ixs", [7, jnp.arange(5)])
+  @pytest.mark.parametrize("tgt_ixs", [[1], jnp.arange(5)])
   @pytest.mark.parametrize("src_ixs", [None, (3, 3)])
   @pytest.mark.parametrize(
       "clazz", [geometry.Geometry, pointcloud.PointCloud, low_rank.LRCGeometry]
@@ -78,12 +78,8 @@ class TestMaskPointCloud:
       geom = clazz(cost_matrix=x @ y.T, scale_cost="mean")
     else:
       geom = clazz(x, y, scale_cost="max_cost", batch_size=5)
-    n = geom.shape[0] if src_ixs is None else 1 if isinstance(
-        src_ixs, int
-    ) else len(src_ixs)
-    m = geom.shape[1] if tgt_ixs is None else 1 if isinstance(
-        tgt_ixs, int
-    ) else len(tgt_ixs)
+    n = geom.shape[0] if src_ixs is None else len(src_ixs)
+    m = geom.shape[1] if tgt_ixs is None else len(tgt_ixs)
 
     if clazz is geometry.Geometry:
       geom_sub = geom.subset(src_ixs, tgt_ixs)

--- a/tests/initializers/linear/sinkhorn_init_test.py
+++ b/tests/initializers/linear/sinkhorn_init_test.py
@@ -30,8 +30,8 @@ def create_sorting_problem(
     batch_size: Optional[int] = None
 ) -> linear_problem.LinearProblem:
   # define ot problem
-  x_init = jnp.array([-1., 0, .22])
-  y_init = jnp.array([0., 0, 1.1])
+  x_init = jnp.array([-1.0, 0.0, 0.22])
+  y_init = jnp.array([0.0, 0.0, 1.1])
   x_rng, y_rng = jax.random.split(rng)
 
   x = jnp.concatenate([x_init, 10 + jnp.abs(jax.random.normal(x_rng, (n,)))])
@@ -200,8 +200,8 @@ class TestSinkhornInitializers:
     )
 
     # check default is 0
-    np.testing.assert_array_equal(0., default_potential_a)
-    np.testing.assert_array_equal(0., default_potential_b)
+    np.testing.assert_array_equal(0.0, default_potential_a)
+    np.testing.assert_array_equal(0.0, default_potential_b)
 
   def test_gauss_pointcloud_geom(self, rng: jax.Array):
     n, m, d = 20, 20, 2

--- a/tests/initializers/linear/sinkhorn_lr_init_test.py
+++ b/tests/initializers/linear/sinkhorn_lr_init_test.py
@@ -109,7 +109,7 @@ class TestLRInitializers:
         pc_out.reg_ot_cost, geom_out.reg_ot_cost, atol=0.5, rtol=0.02
     )
 
-  @pytest.mark.parametrize("epsilon", [0., 1e-1])
+  @pytest.mark.parametrize("epsilon", [0.0, 1e-1])
   def test_better_initialization_helps(self, rng: jax.Array, epsilon: float):
     n, d, rank = 81, 13, 3
     rng1, rng2 = jax.random.split(rng, 2)

--- a/tests/initializers/quadratic/gw_init_test.py
+++ b/tests/initializers/quadratic/gw_init_test.py
@@ -47,7 +47,7 @@ class TestQuadraticInitializers:
     assert solver.initializer is q_init
     assert solver.initializer.rank == rank
 
-  @pytest.mark.parametrize("eps", [0., 1e-2])
+  @pytest.mark.parametrize("eps", [0.0, 1e-2])
   def test_gw_better_initialization_helps(self, rng: jax.Array, eps: float):
     n, m, d1, d2, rank = 83, 84, 8, 6, 4
     rng1, rng2, rng3, rng4 = jax.random.split(rng, 4)
@@ -83,5 +83,5 @@ class TestQuadraticInitializers:
     kmeans_errors = out_kmeans.errors[out_kmeans.errors > -1]
 
     np.testing.assert_array_less(kmeans_cost, random_cost)
-    np.testing.assert_array_equal(random_errors >= 0., True)
-    np.testing.assert_array_equal(kmeans_errors >= 0., True)
+    np.testing.assert_array_equal(random_errors >= 0.0, True)
+    np.testing.assert_array_equal(kmeans_errors >= 0.0, True)

--- a/tests/math/lse_test.py
+++ b/tests/math/lse_test.py
@@ -43,8 +43,8 @@ class TestGeometryLse:
       val_meps = lse(mat - eps * delta_mat, axis, None, False)[0]
       np.testing.assert_allclose((val_peps - val_meps) / (2 * eps),
                                  jnp.sum(delta_mat * g[0]),
-                                 rtol=1e-03,
-                                 atol=1e-02)
+                                 rtol=1e-3,
+                                 atol=1e-2)
     for b, dim, axis in zip((b_0, b_1), (m, n), (1, 0)):
       delta_b = jax.random.normal(rngs[4], (dim,)).reshape(b.shape)
       _, g = lse(mat, axis, b, True)
@@ -54,5 +54,5 @@ class TestGeometryLse:
       np.testing.assert_allclose((val_peps - val_meps) / (2 * eps),
                                  jnp.sum(delta_mat * g[0]) +
                                  jnp.sum(delta_b * g[1]),
-                                 rtol=1e-03,
-                                 atol=1e-02)
+                                 rtol=1e-3,
+                                 atol=1e-2)

--- a/tests/math/matrix_square_root_test.py
+++ b/tests/math/matrix_square_root_test.py
@@ -30,7 +30,7 @@ def _get_random_spd_matrix(dim: int, rng: jax.Array):
 
   # Step 2: generate random eigenvalues in [1/2. , 2.] to ensure the condition
   # number is reasonable.
-  eigs = 2. ** (2. * jax.random.uniform(subrng1, shape=(dim,)) - 1.)
+  eigs = 2.0 ** (2.0 * jax.random.uniform(subrng1, shape=(dim,)) - 1.0)
 
   return jnp.matmul(eigs[None, :] * q, jnp.transpose(q))
 
@@ -51,7 +51,7 @@ def _get_test_fn(
   m1 = _get_random_spd_matrix(dim=dim, rng=subrng1)
   dx = _get_random_spd_matrix(dim=dim, rng=subrng2)
   unit = jax.random.normal(subrng3, shape=(dim, dim))
-  unit /= jnp.sqrt(jnp.sum(unit ** 2.))
+  unit /= jnp.sqrt(jnp.sum(unit ** 2))
 
   def _test_fn(x: jnp.ndarray, **kwargs: Any) -> jnp.ndarray:
     # m is the product of 2 symmetric, positive definite matrices
@@ -154,7 +154,7 @@ class TestMatrixSquareRoot:
     x = matrix_square_root.solve_sylvester_bartels_stewart(
         a=self.a[0], b=self.b[0], c=self.c[0]
     )
-    np.testing.assert_allclose(self.x[0], x, atol=1.e-5)
+    np.testing.assert_allclose(self.x[0], x, atol=1e-5)
 
   # requires Schur decomposition, which jax does not implement on GPU
   @pytest.mark.cpu()
@@ -162,15 +162,15 @@ class TestMatrixSquareRoot:
     x = matrix_square_root.solve_sylvester_bartels_stewart(
         a=self.a, b=self.b, c=self.c
     )
-    np.testing.assert_allclose(self.x, x, atol=1.e-5)
+    np.testing.assert_allclose(self.x, x, atol=1e-5)
     x = matrix_square_root.solve_sylvester_bartels_stewart(
         a=self.a[None], b=self.b[None], c=self.c[None]
     )
-    np.testing.assert_allclose(self.x, x[0], atol=1.e-5)
+    np.testing.assert_allclose(self.x, x[0], atol=1e-5)
     x = matrix_square_root.solve_sylvester_bartels_stewart(
         a=self.a[None, None], b=self.b[None, None], c=self.c[None, None]
     )
-    np.testing.assert_allclose(self.x, x[0, 0], atol=1.e-5)
+    np.testing.assert_allclose(self.x, x[0, 0], atol=1e-5)
 
   # requires Schur decomposition, which jax does not implement on GPU
   @pytest.mark.cpu()
@@ -196,6 +196,6 @@ class TestMatrixSquareRoot:
     for _ in range(n_tests):
       rng, subrng = jax.random.split(rng)
       test_fn = _get_test_fn(fn, dim=dim, rng=subrng, threshold=1e-5)
-      expected = (test_fn(epsilon) - test_fn(-epsilon)) / (2. * epsilon)
-      actual = jax.grad(test_fn)(0.)
+      expected = (test_fn(epsilon) - test_fn(-epsilon)) / (2.0 * epsilon)
+      actual = jax.grad(test_fn)(0.0)
       np.testing.assert_allclose(actual, expected, atol=atol, rtol=rtol)

--- a/tests/math/matrix_square_root_test.py
+++ b/tests/math/matrix_square_root_test.py
@@ -23,14 +23,14 @@ from ott.math import matrix_square_root
 def _get_random_spd_matrix(dim: int, rng: jax.Array):
   # Get a random symmetric, positive definite matrix of a specified size.
 
-  rng, subrng0, subrng1 = jax.random.split(rng, num=3)
+  rng, subrng0, subrng1 = jax.random.split(rng, 3)
   # Step 1: generate a random orthogonal matrix
-  m = jax.random.normal(key=subrng0, shape=[dim, dim])
+  m = jax.random.normal(subrng0, shape=[dim, dim])
   q, _ = jnp.linalg.qr(m)
 
   # Step 2: generate random eigenvalues in [1/2. , 2.] to ensure the condition
   # number is reasonable.
-  eigs = 2. ** (2. * jax.random.uniform(key=subrng1, shape=(dim,)) - 1.)
+  eigs = 2. ** (2. * jax.random.uniform(subrng1, shape=(dim,)) - 1.)
 
   return jnp.matmul(eigs[None, :] * q, jnp.transpose(q))
 
@@ -50,7 +50,7 @@ def _get_test_fn(
   m0 = _get_random_spd_matrix(dim=dim, rng=subrng0)
   m1 = _get_random_spd_matrix(dim=dim, rng=subrng1)
   dx = _get_random_spd_matrix(dim=dim, rng=subrng2)
-  unit = jax.random.normal(key=subrng3, shape=(dim, dim))
+  unit = jax.random.normal(subrng3, shape=(dim, dim))
   unit /= jnp.sqrt(jnp.sum(unit ** 2.))
 
   def _test_fn(x: jnp.ndarray, **kwargs: Any) -> jnp.ndarray:
@@ -79,9 +79,9 @@ class TestMatrixSquareRoot:
     m = 3
     n = 2
     rng, subrng0, subrng1, subrng2 = jax.random.split(rng, 4)
-    self.a = jax.random.normal(key=subrng0, shape=(2, m, m))
-    self.b = jax.random.normal(key=subrng1, shape=(2, n, n))
-    self.x = jax.random.normal(key=subrng2, shape=(2, m, n))
+    self.a = jax.random.normal(subrng0, shape=(2, m, m))
+    self.b = jax.random.normal(subrng1, shape=(2, n, n))
+    self.x = jax.random.normal(subrng2, shape=(2, m, n))
     # make sure the system has a solution
     self.c = jnp.matmul(self.a, self.x) - jnp.matmul(self.x, self.b)
 

--- a/tests/neural/losses_test.py
+++ b/tests/neural/losses_test.py
@@ -96,7 +96,7 @@ class TestMongeGap:
     # generate data
     rng1, rng2 = jax.random.split(rng, 2)
     source = jax.random.normal(rng1, (n_samples, n_features))
-    target = jax.random.normal(rng2, (n_samples, n_features)) * .1 + 3.
+    target = jax.random.normal(rng2, (n_samples, n_features)) * 0.1 + 3.0
 
     # compute the Monge gaps for the euclidean cost
     monge_gap_from_samples_value_eucl = losses.monge_gap_from_samples(

--- a/tests/neural/map_estimator_test.py
+++ b/tests/neural/map_estimator_test.py
@@ -67,7 +67,7 @@ class TestMapEstimator:
         fitting_loss=fitting_loss,
         regularizer=regularizer,
         model=model,
-        regularizer_strength=1.,
+        regularizer_strength=1.0,
         num_train_iters=15,
         logging=True,
         valid_freq=5,

--- a/tests/problems/linear/potentials_test.py
+++ b/tests/problems/linear/potentials_test.py
@@ -165,7 +165,7 @@ class TestEntropicPotentials:
       div = sdiv(x, z).divergence
 
     div_0 = sdiv(x, y).divergence
-    mult = .1 if p > 1.0 else .25
+    mult = 0.1 if p > 1.0 else 0.25
     # check we have moved points much closer to target
     assert div < mult * div_0
 
@@ -212,7 +212,7 @@ class TestEntropicPotentials:
 
       div_0 = sdiv(x, y).divergence
       # check we have moved points much closer to target
-      assert div < .1 * div_0
+      assert div < 0.1 * div_0
 
   @pytest.mark.parametrize("jit", [False, True])
   def test_distance_differentiability(self, rng: jax.Array, jit: bool):
@@ -233,7 +233,7 @@ class TestEntropicPotentials:
     dx = grad_dist(x, y)
 
     expected = pots.distance(x + v_x, y) - pots.distance(x - v_x, y)
-    actual = 2. * jnp.vdot(v_x, dx)
+    actual = 2.0 * jnp.vdot(v_x, dx)
     np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=1e-4)
 
   @pytest.mark.parametrize("eps", [None, 1e-1, 1e1, 1e2, 1e3])
@@ -241,7 +241,7 @@ class TestEntropicPotentials:
     rng1, rng2, rng3 = jax.random.split(rng, 3)
     n, m, d = 32, 36, 4
     fwd = True
-    mu0, mu1 = -5., 5.
+    mu0, mu1 = -5.0, 5.0
 
     x = jax.random.normal(rng1, (n, d)) + mu0
     y = jax.random.normal(rng2, (m, d)) + mu1

--- a/tests/solvers/linear/continuous_barycenter_test.py
+++ b/tests/solvers/linear/continuous_barycenter_test.py
@@ -111,7 +111,7 @@ class TestBarycenter:
     # (this is because sampled points were equally set in either [0,1]^4
     # or [2,3]^4)
     assert jnp.all(out.x.ravel() < 2.3)
-    assert jnp.all(out.x.ravel() > .7)
+    assert jnp.all(out.x.ravel() > 0.7)
 
   @pytest.mark.parametrize("segment_before", [False, True])
   def test_barycenter_jit(self, rng: jax.Array, segment_before: bool):
@@ -164,7 +164,7 @@ class TestBarycenter:
     # (this is because sampled points were equally set in either [0,1]^4
     # or [2,3]^4)
     assert jnp.all(out.x.ravel() < 2.3)
-    assert jnp.all(out.x.ravel() > .7)
+    assert jnp.all(out.x.ravel() > 0.7)
 
   @pytest.mark.fast()
   def test_bures_barycenter(
@@ -181,8 +181,8 @@ class TestBarycenter:
     barycentric_weights = jnp.asarray([0.5, 0.5])
     bures_cost = costs.Bures(dimension=dimension)
 
-    means1 = jnp.array([[-1., 1.], [-1., -1.]])
-    means2 = jnp.array([[1., 1.], [1., -1.]])
+    means1 = jnp.array([[-1.0, 1.0], [-1.0, -1.0]])
+    means2 = jnp.array([[1.0, 1.0], [1.0, -1.0]])
     sigma = 0.01
     covs1 = sigma * jnp.asarray([
         jnp.eye(dimension) for _ in range(num_components)
@@ -238,11 +238,17 @@ class TestBarycenter:
 
     try:
       np.testing.assert_allclose(
-          means_bary, jnp.array([[0., 1.], [0., -1.]]), rtol=1e-02, atol=1e-02
+          means_bary,
+          jnp.array([[0.0, 1.0], [0.0, -1.0]]),
+          rtol=1e-02,
+          atol=1e-02
       )
     except AssertionError:
       np.testing.assert_allclose(
-          means_bary, jnp.array([[0., -1.], [0., 1.]]), rtol=1e-02, atol=1e-02
+          means_bary,
+          jnp.array([[0.0, -1.0], [0.0, 1.0]]),
+          rtol=1e-02,
+          atol=1e-02
       )
 
     np.testing.assert_allclose(
@@ -257,7 +263,7 @@ class TestBarycenter:
       self,
       rng: jax.Array,
   ):
-    alpha = 5.
+    alpha = 5.0
     epsilon = 0.01
     dim = 3
     jit = True
@@ -280,7 +286,7 @@ class TestBarycenter:
     ridges = jnp.array([jnp.ones(dim), 5 * jnp.ones(dim)])
     stdev_means = 0.1 * jnp.mean(ridges, axis=1)
     stdev_covs = jax.random.uniform(
-        rngs[1], shape=(num_measures,), minval=0., maxval=10.
+        rngs[1], shape=(num_measures,), minval=0.0, maxval=10.0
     )
 
     seeds = jax.random.randint(

--- a/tests/solvers/linear/continuous_barycenter_test.py
+++ b/tests/solvers/linear/continuous_barycenter_test.py
@@ -240,22 +240,22 @@ class TestBarycenter:
       np.testing.assert_allclose(
           means_bary,
           jnp.array([[0.0, 1.0], [0.0, -1.0]]),
-          rtol=1e-02,
-          atol=1e-02
+          rtol=1e-2,
+          atol=1e-2
       )
     except AssertionError:
       np.testing.assert_allclose(
           means_bary,
           jnp.array([[0.0, -1.0], [0.0, 1.0]]),
-          rtol=1e-02,
-          atol=1e-02
+          rtol=1e-2,
+          atol=1e-2
       )
 
     np.testing.assert_allclose(
         covs_bary,
         jnp.array([sigma * jnp.eye(dimension) for i in range(bar_size)]),
-        rtol=1e-05,
-        atol=1e-05
+        rtol=1e-5,
+        atol=1e-5
     )
 
   @pytest.mark.fast()

--- a/tests/solvers/linear/discrete_barycenter_test.py
+++ b/tests/solvers/linear/discrete_barycenter_test.py
@@ -79,8 +79,8 @@ class TestDiscreteBarycenter:
     ma = 0.2
     mb = 0.8
     # define two narrow Gaussian bumps in segment [0,1]
-    a = jnp.exp(-(jnp.arange(0, n) / (n - 1) - ma) ** 2 / .01) + 1e-10
-    b = jnp.exp(-(jnp.arange(0, n) / (n - 1) - mb) ** 2 / .01) + 1e-10
+    a = jnp.exp(-(jnp.arange(0, n) / (n - 1) - ma) ** 2 / 0.01) + 1e-10
+    b = jnp.exp(-(jnp.arange(0, n) / (n - 1) - mb) ** 2 / 0.01) + 1e-10
     a = a / jnp.sum(a)
     b = b / jnp.sum(b)
 
@@ -90,7 +90,7 @@ class TestDiscreteBarycenter:
     # choose a different support, half the size, for the barycenter.
     # note this is the reason why we do not use debiasing in this case.
     x_support_bar = jnp.atleast_2d((jnp.arange(0, (n / 2)) /
-                                    (n / 2 - 1) - .5) * .9 + .5).T
+                                    (n / 2 - 1) - 0.5) * 0.9 + 0.5).T
 
     geom = pointcloud.PointCloud(x, x_support_bar, epsilon=epsilon)
     fixed_bp = bp.FixedBarycenterProblem(geom, a=jnp.stack((a, b)))

--- a/tests/solvers/linear/sinkhorn_diff_test.py
+++ b/tests/solvers/linear/sinkhorn_diff_test.py
@@ -36,8 +36,8 @@ class TestSinkhornImplicit:
     self.rngs = rngs
     self.x = jax.random.uniform(rngs[0], (self.n, self.dim))
     self.y = jax.random.uniform(rngs[1], (self.m, self.dim))
-    a = jax.random.uniform(rngs[2], (self.n,)) + .1
-    b = jax.random.uniform(rngs[3], (self.m,)) + .1
+    a = jax.random.uniform(rngs[2], (self.n,)) + 0.1
+    b = jax.random.uniform(rngs[3], (self.m,)) + 0.1
     self.a = a / jnp.sum(a)
     self.b = b / jnp.sum(b)
 
@@ -46,7 +46,7 @@ class TestSinkhornImplicit:
   def test_implicit_differentiation_versus_autodiff(
       self, lse_mode: bool, threshold: float, pcg: bool
   ):
-    epsilon = 0.05
+    epsilon = 5e-2
 
     def loss_g(a: jnp.ndarray, x: jnp.ndarray, implicit: bool = True) -> float:
       implicit_diff = implicit_lib.ImplicitDiff() if implicit else None
@@ -341,8 +341,8 @@ class TestSinkhornJacobian:
 
   @pytest.mark.fast.with_args(
       "lse_mode,tau_a,tau_b,arg,axis",
-      ((True, 1.0, 1.0, 0, 1), (False, 1.0, 1.0, 1, 0), (True, .93, 1.0, 1, 1),
-       (True, .93, .95, 0, 0)),
+      ((True, 1.0, 1.0, 0, 1), (False, 1.0, 1.0, 1, 0), (True, 0.93, 1.0, 1, 1),
+       (True, 0.93, 0.95, 0, 0)),
       only_fast=0
   )
   def test_apply_transport_jacobian(
@@ -369,11 +369,11 @@ class TestSinkhornJacobian:
     rngs = jax.random.split(rng, 9)
     x = jax.random.uniform(rngs[0], (n, dim)) / dim
     y = jax.random.uniform(rngs[1], (m, dim)) / dim
-    a = jax.random.uniform(rngs[2], (n,)) + .2
-    b = jax.random.uniform(rngs[3], (m,)) + .2
+    a = jax.random.uniform(rngs[2], (n,)) + 0.2
+    b = jax.random.uniform(rngs[3], (m,)) + 0.2
     a = a / (0.5 * n) if tau_a < 1.0 else a / jnp.sum(a)
     b = b / (0.5 * m) if tau_b < 1.0 else b / jnp.sum(b)
-    vec = jax.random.uniform(rngs[4], (m if axis else n,)) - .5
+    vec = jax.random.uniform(rngs[4], (m if axis else n,)) - 0.5
 
     delta_a = jax.random.uniform(rngs[5], (n,))
     if tau_a == 1.0:
@@ -451,8 +451,8 @@ class TestSinkhornJacobian:
 
   @pytest.mark.fast.with_args(
       lse_mode=[True, False],
-      tau_a=[1.0, .93],
-      tau_b=[1.0, .91],
+      tau_a=[1.0, 0.93],
+      tau_b=[1.0, 0.91],
       shape=[(22, 25), (27, 18)],
       arg=[0, 1],
       only_fast=0,
@@ -470,8 +470,8 @@ class TestSinkhornJacobian:
     rngs = jax.random.split(rng, 7)
     x = jax.random.uniform(rngs[0], (n, dim))
     y = jax.random.uniform(rngs[1], (m, dim))
-    a = jax.random.uniform(rngs[2], (n,)) + .2
-    b = jax.random.uniform(rngs[3], (m,)) + .2
+    a = jax.random.uniform(rngs[2], (n,)) + 0.2
+    b = jax.random.uniform(rngs[3], (m,)) + 0.2
     a = a / (0.5 * n) if tau_a < 1.0 else a / jnp.sum(a)
     b = b / (0.5 * m) if tau_b < 1.0 else b / jnp.sum(b)
     random_dir = jax.random.uniform(rngs[4], (n,)) / n
@@ -546,8 +546,8 @@ class TestSinkhornGradGrid:
     eps = 1e-3  # perturbation magnitude
     rngs = jax.random.split(rng, 6)
     x = (
-        jnp.array([.0, 1.0]), jnp.array([.3, .4,
-                                         .7]), jnp.array([1.0, 1.3, 2.4, 3.7])
+        jnp.array([0.0, 1.0]), jnp.array([0.3, 0.4,
+                                          0.7]), jnp.array([1.0, 1.3, 2.4, 3.7])
     )
     grid_size = tuple(xs.shape[0] for xs in x)
     a = jax.random.uniform(rngs[0], grid_size) + 1.0
@@ -592,8 +592,8 @@ class TestSinkhornGradGrid:
     rngs = jax.random.split(rng, 3)
     # yapf: disable
     x = (
-        jnp.asarray([.0, 1.0]),
-        jnp.asarray([.3, .4, .7]),
+        jnp.asarray([0.0, 1.0]),
+        jnp.asarray([0.3, 0.4, 0.7]),
         jnp.asarray([1.0, 1.3, 2.4, 3.7])
     )
     # yapf: enable
@@ -629,8 +629,8 @@ class TestSinkhornJacobianPreconditioning:
 
   @pytest.mark.fast.with_args(
       lse_mode=[True, False],
-      tau_a=[1.0, .94],
-      tau_b=[1.0, .91],
+      tau_a=[1.0, 0.94],
+      tau_b=[1.0, 0.91],
       shape=[(18, 19), (27, 18)],
       arg=[0, 1],
       only_fast=[0, -1],
@@ -648,8 +648,8 @@ class TestSinkhornJacobianPreconditioning:
     rngs = jax.random.split(rng, 7)
     x = jax.random.uniform(rngs[0], (n, dim))
     y = jax.random.uniform(rngs[1], (m, dim))
-    a = jax.random.uniform(rngs[2], (n,)) + .2
-    b = jax.random.uniform(rngs[3], (m,)) + .2
+    a = jax.random.uniform(rngs[2], (n,)) + 0.2
+    b = jax.random.uniform(rngs[3], (m,)) + 0.2
     a = a / (0.5 * n) if tau_a < 1.0 else a / jnp.sum(a)
     b = b / (0.5 * m) if tau_b < 1.0 else b / jnp.sum(b)
     random_dir = jax.random.uniform(rngs[4], (n,)) / n

--- a/tests/solvers/linear/sinkhorn_diff_test.py
+++ b/tests/solvers/linear/sinkhorn_diff_test.py
@@ -99,9 +99,10 @@ class TestSinkhornImplicit:
     reg_ot_delta_minus = loss(self.a - eps * delta, self.x)
     delta_dot_grad = jnp.sum(delta * grad_loss_imp[0])
     np.testing.assert_allclose(
-        delta_dot_grad, (reg_ot_delta_plus - reg_ot_delta_minus) / (2 * eps),
-        rtol=1e-02,
-        atol=1e-02
+        delta_dot_grad,
+        (reg_ot_delta_plus - reg_ot_delta_minus) / (2.0 * eps),
+        rtol=1e-2,
+        atol=1e-2,
     )
     # note how we removed gradients below. This is because gradients are only
     # determined up to additive constant here (the primal variable is in the
@@ -109,8 +110,8 @@ class TestSinkhornImplicit:
     np.testing.assert_allclose(
         grad_loss_imp[0] - jnp.mean(grad_loss_imp[0]),
         grad_loss_auto[0] - jnp.mean(grad_loss_auto[0]),
-        rtol=1e-02,
-        atol=1e-02
+        rtol=1e-2,
+        atol=1e-2,
     )
 
     # test gradient w.r.t. x works and gradient implicit ~= gradient autodiff
@@ -119,12 +120,13 @@ class TestSinkhornImplicit:
     reg_ot_delta_minus = loss(self.a, self.x - eps * delta)
     delta_dot_grad = jnp.sum(delta * grad_loss_imp[1])
     np.testing.assert_allclose(
-        delta_dot_grad, (reg_ot_delta_plus - reg_ot_delta_minus) / (2 * eps),
-        rtol=1e-02,
-        atol=1e-02
+        delta_dot_grad,
+        (reg_ot_delta_plus - reg_ot_delta_minus) / (2.0 * eps),
+        rtol=1e-2,
+        atol=1e-2,
     )
     np.testing.assert_allclose(
-        grad_loss_imp[1], grad_loss_auto[1], rtol=1e-02, atol=1e-02
+        grad_loss_imp[1], grad_loss_auto[1], rtol=1e-2, atol=1e-2
     )
 
 
@@ -171,9 +173,10 @@ class TestSinkhornJacobian:
 
     assert not jnp.any(jnp.isnan(delta_dot_grad))
     np.testing.assert_allclose(
-        delta_dot_grad, (reg_ot_delta_plus - reg_ot_delta_minus) / (2 * eps),
-        rtol=1e-03,
-        atol=1e-02
+        delta_dot_grad,
+        (reg_ot_delta_plus - reg_ot_delta_minus) / (2.0 * eps),
+        rtol=1e-3,
+        atol=1e-2,
     )
 
   @pytest.mark.parametrize(("lse_mode", "shape_data"), [(True, (7, 9)),
@@ -215,14 +218,14 @@ class TestSinkhornJacobian:
     # third calculation of gradient
     loss_delta_plus, _ = loss_fn(cost_matrix + eps * delta)
     loss_delta_minus, _ = loss_fn(cost_matrix - eps * delta)
-    finite_diff_grad = (loss_delta_plus - loss_delta_minus) / (2 * eps)
+    finite_diff_grad = (loss_delta_plus - loss_delta_minus) / (2.0 * eps)
 
-    np.testing.assert_allclose(custom_grad, other_grad, rtol=1e-02, atol=1e-02)
+    np.testing.assert_allclose(custom_grad, other_grad, rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(
-        custom_grad, finite_diff_grad, rtol=1e-02, atol=1e-02
+        custom_grad, finite_diff_grad, rtol=1e-2, atol=1e-2
     )
     np.testing.assert_allclose(
-        other_grad, finite_diff_grad, rtol=1e-02, atol=1e-02
+        other_grad, finite_diff_grad, rtol=1e-2, atol=1e-2
     )
     np.testing.assert_array_equal(jnp.isnan(custom_grad), False)
 
@@ -305,14 +308,14 @@ class TestSinkhornJacobian:
     # third calculation of gradient
     loss_delta_plus, _ = loss_fn(x + eps * delta, y)
     loss_delta_minus, _ = loss_fn(x - eps * delta, y)
-    finite_diff_grad = (loss_delta_plus - loss_delta_minus) / (2 * eps)
+    finite_diff_grad = (loss_delta_plus - loss_delta_minus) / (2.0 * eps)
 
-    np.testing.assert_allclose(custom_grad, other_grad, rtol=1e-02, atol=1e-02)
+    np.testing.assert_allclose(custom_grad, other_grad, rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(
-        custom_grad, finite_diff_grad, rtol=1e-02, atol=1e-02
+        custom_grad, finite_diff_grad, rtol=1e-2, atol=1e-2
     )
     np.testing.assert_allclose(
-        other_grad, finite_diff_grad, rtol=1e-02, atol=1e-02
+        other_grad, finite_diff_grad, rtol=1e-2, atol=1e-2
     )
     np.testing.assert_array_equal(jnp.isnan(custom_grad), False)
 
@@ -578,9 +581,10 @@ class TestSinkhornGradGrid:
         ])
     )
     np.testing.assert_allclose(
-        delta_dot_grad, (reg_ot_delta_plus - reg_ot_delta_minus) / (2 * eps),
-        rtol=1e-03,
-        atol=1e-02
+        delta_dot_grad,
+        (reg_ot_delta_plus - reg_ot_delta_minus) / (2.0 * eps),
+        rtol=1e-3,
+        atol=1e-2,
     )
 
   @pytest.mark.parametrize("lse_mode", [False, True])
@@ -619,9 +623,10 @@ class TestSinkhornGradGrid:
     reg_ot_delta_minus = reg_ot(a - eps * delta, b)
     delta_dot_grad = jnp.sum(delta * grad_reg_ot)
     np.testing.assert_allclose(
-        delta_dot_grad, (reg_ot_delta_plus - reg_ot_delta_minus) / (2 * eps),
-        rtol=1e-03,
-        atol=1e-02
+        delta_dot_grad,
+        (reg_ot_delta_plus - reg_ot_delta_minus) / (2.0 * eps),
+        rtol=1e-3,
+        atol=1e-2,
     )
 
 

--- a/tests/solvers/linear/sinkhorn_misc_test.py
+++ b/tests/solvers/linear/sinkhorn_misc_test.py
@@ -30,8 +30,8 @@ class TestSinkhornAnderson:
 
   @pytest.mark.fast.with_args(
       lse_mode=[True, False],
-      tau_a=[1.0, .98],
-      tau_b=[1.0, .985],
+      tau_a=[1.0, 0.98],
+      tau_b=[1.0, 0.985],
       only_fast=0,
   )
   def test_anderson(
@@ -49,7 +49,7 @@ class TestSinkhornAnderson:
     dim = 4
     rngs = jax.random.split(rng, 9)
     x = jax.random.uniform(rngs[0], (n, dim)) / dim
-    y = jax.random.uniform(rngs[1], (m, dim)) / dim + .2
+    y = jax.random.uniform(rngs[1], (m, dim)) / dim + 0.2
     a = jax.random.uniform(rngs[2], (n,))
     b = jax.random.uniform(rngs[3], (m,))
     a = a.at[0].set(0)
@@ -118,8 +118,8 @@ class TestSinkhornBures:
     self.y = jnp.concatenate(
         (m_y.reshape((self.m, -1)), sig_y.reshape((self.m, -1))), axis=1
     )
-    a = jax.random.uniform(self.rngs[4], (self.n,)) + .1
-    b = jax.random.uniform(self.rngs[5], (self.m,)) + .1
+    a = jax.random.uniform(self.rngs[4], (self.n,)) + 0.1
+    b = jax.random.uniform(self.rngs[5], (self.m,)) + 0.1
     self.a = a / jnp.sum(a)
     self.b = b / jnp.sum(b)
 
@@ -134,7 +134,7 @@ class TestSinkhornBures:
       rng1, rng2 = jax.random.split(rng, 2)
       ws_x = jnp.abs(jax.random.normal(rng1, (self.x.shape[0], 1))) + 1e-1
       ws_y = jnp.abs(jax.random.normal(rng2, (self.y.shape[0], 1))) + 1e-1
-      ws_x = ws_x.at[0].set(0.)
+      ws_x = ws_x.at[0].set(0.0)
       x = jnp.concatenate([ws_x, self.x], axis=1)
       y = jnp.concatenate([ws_y, self.y], axis=1)
       cost_fn = costs.UnbalancedBures(dimension=self.dim, gamma=0.9, sigma=0.98)
@@ -322,8 +322,8 @@ class TestSinkhornJIT:
     self.rngs = rngs
     self.x = jax.random.uniform(rngs[0], (self.n, self.dim))
     self.y = jax.random.uniform(rngs[1], (self.m, self.dim))
-    a = jax.random.uniform(rngs[2], (self.n,)) + .1
-    b = jax.random.uniform(rngs[3], (self.m,)) + .1
+    a = jax.random.uniform(rngs[2], (self.n,)) + 0.1
+    b = jax.random.uniform(rngs[3], (self.m,)) + 0.1
 
     self.a = a / jnp.sum(a)
     self.b = b / jnp.sum(b)
@@ -383,8 +383,8 @@ class TestSinkhornJIT:
     non_jitted_loss, non_jitted_grad = val_grad(self.a, self.x)
 
     chex.assert_trees_all_close(
-        jitted_loss, non_jitted_loss, atol=1e-6, rtol=0.
+        jitted_loss, non_jitted_loss, atol=1e-6, rtol=0.0
     )
     chex.assert_trees_all_close(
-        jitted_grad, non_jitted_grad, atol=1e-6, rtol=0.
+        jitted_grad, non_jitted_grad, atol=1e-6, rtol=0.0
     )

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -98,8 +98,8 @@ class TestSinkhorn:
         geom_1,
         a=self.a,
         b=self.b,
-        tau_a=.99,
-        tau_b=.97,
+        tau_a=0.99,
+        tau_b=0.97,
     ).f
 
     # Second geom does not provide whether epsilon is relative.
@@ -125,9 +125,9 @@ class TestSinkhorn:
   @pytest.mark.fast.with_args(
       lse_mode=[False, True],
       init=[5],
-      decay=[.9],
-      tau_a=[1.0, .93],
-      tau_b=[1.0, .91],
+      decay=[0.9],
+      tau_a=[1.0, 0.93],
+      tau_b=[1.0, 0.91],
       only_fast=0
   )
   def test_autoepsilon_with_decay(
@@ -550,9 +550,9 @@ class TestSinkhorn:
     solver = sinkhorn.Sinkhorn(lse_mode=lse_mode, recenter_potentials=True)
 
     f = solver(prob).f
-    f_mean = jnp.mean(jnp.where(jnp.isfinite(f), f, 0.))
+    f_mean = jnp.mean(jnp.where(jnp.isfinite(f), f, 0.0))
 
-    np.testing.assert_allclose(f_mean, 0., rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(f_mean, 0.0, rtol=1e-6, atol=1e-6)
 
   @pytest.mark.parametrize(("use_tqdm", "custom_buffer"), [(False, False),
                                                            (False, True),

--- a/tests/solvers/quadratic/fgw_test.py
+++ b/tests/solvers/quadratic/fgw_test.py
@@ -90,8 +90,8 @@ class TestFusedGromovWasserstein:
     gi_a, gi_b = grad_matrices[0]
     g_a, g_b = grad_matrices[1]
 
-    np.testing.assert_allclose(g_a, gi_a, rtol=1e-02, atol=1e-02)
-    np.testing.assert_allclose(g_b, gi_b, rtol=1e-02, atol=1e-02)
+    np.testing.assert_allclose(g_a, gi_a, rtol=1e-2, atol=1e-2)
+    np.testing.assert_allclose(g_b, gi_b, rtol=1e-2, atol=1e-2)
 
   @pytest.mark.parametrize(("lse_mode", "is_cost"), [(True, False),
                                                      (False, True)],
@@ -143,13 +143,13 @@ class TestFusedGromovWasserstein:
     gi_x, gi_y, gi_xy = grad_matrices[0]
     g_x, g_y, g_xy = grad_matrices[1]
 
-    np.testing.assert_allclose(g_x, gi_x, rtol=1e-02, atol=1e-02)
-    np.testing.assert_allclose(g_y, gi_y, rtol=1e-02, atol=1e-02)
+    np.testing.assert_allclose(g_x, gi_x, rtol=1e-2, atol=1e-2)
+    np.testing.assert_allclose(g_y, gi_y, rtol=1e-2, atol=1e-2)
     if is_cost:
-      np.testing.assert_allclose(g_xy, gi_xy, rtol=1e-02, atol=1e-02)
+      np.testing.assert_allclose(g_xy, gi_xy, rtol=1e-2, atol=1e-2)
     else:
-      np.testing.assert_allclose(g_xy[0], gi_xy[0], rtol=1e-02, atol=1e-02)
-      np.testing.assert_allclose(g_xy[1], gi_xy[1], rtol=1e-02, atol=1e-02)
+      np.testing.assert_allclose(g_xy[0], gi_xy[0], rtol=1e-2, atol=1e-2)
+      np.testing.assert_allclose(g_xy[1], gi_xy[1], rtol=1e-2, atol=1e-2)
 
   def test_fgw_adaptive_threshold(self):
     """Checking solution is improved with smaller threshold for convergence."""
@@ -210,7 +210,7 @@ class TestFusedGromovWasserstein:
       assert not jnp.any(jnp.isnan(grad_matrices[i][0]))
 
     np.testing.assert_allclose(
-        grad_matrices[0][0], grad_matrices[1][0], rtol=1e-02, atol=1e-02
+        grad_matrices[0][0], grad_matrices[1][0], rtol=1e-2, atol=1e-2
     )
 
   @pytest.mark.limit_memory("200 MB")

--- a/tests/solvers/quadratic/fgw_test.py
+++ b/tests/solvers/quadratic/fgw_test.py
@@ -282,9 +282,9 @@ class TestFusedGromovWasserstein:
   def test_fgw_scale_cost(self, scale_cost: Literal["mean", "max_cost"]):
     epsilon = 0.1
     fused_penalty = 1
-    geom_x = pointcloud.PointCloud(self.x, scale_cost=1.)
-    geom_y = pointcloud.PointCloud(self.y, scale_cost=1.)
-    geom_xy = pointcloud.PointCloud(self.x_2, self.y_2, scale_cost=1.)
+    geom_x = pointcloud.PointCloud(self.x, scale_cost=1.0)
+    geom_y = pointcloud.PointCloud(self.y, scale_cost=1.0)
+    geom_xy = pointcloud.PointCloud(self.x_2, self.y_2, scale_cost=1.0)
     geom_x_scaled = pointcloud.PointCloud(self.x, scale_cost=scale_cost)
     geom_y_scaled = pointcloud.PointCloud(self.y, scale_cost=scale_cost)
     geom_xy_scaled = pointcloud.PointCloud(

--- a/tests/solvers/quadratic/gw_test.py
+++ b/tests/solvers/quadratic/gw_test.py
@@ -191,10 +191,10 @@ class TestGromovWasserstein:
       )
 
     np.testing.assert_allclose(
-        grad_matrices[0][0], grad_matrices[1][0], rtol=1e-02, atol=1e-02
+        grad_matrices[0][0], grad_matrices[1][0], rtol=1e-2, atol=1e-2
     )
     np.testing.assert_allclose(
-        grad_matrices[0][1], grad_matrices[1][1], rtol=1e-02, atol=1e-02
+        grad_matrices[0][1], grad_matrices[1][1], rtol=1e-2, atol=1e-2
     )
 
   @pytest.mark.fast()
@@ -284,10 +284,10 @@ class TestGromovWasserstein:
       assert not jnp.any(jnp.isnan(grad_matrices[i][1]))
 
     np.testing.assert_allclose(
-        grad_matrices[0][0], grad_matrices[1][0], rtol=1e-02, atol=1e-02
+        grad_matrices[0][0], grad_matrices[1][0], rtol=1e-2, atol=1e-2
     )
     np.testing.assert_allclose(
-        grad_matrices[0][1], grad_matrices[1][1], rtol=1e-02, atol=1e-02
+        grad_matrices[0][1], grad_matrices[1][1], rtol=1e-2, atol=1e-2
     )
 
   def test_gw_adaptive_threshold(self):

--- a/tests/tools/gaussian_mixture/fit_gmm_pair_test.py
+++ b/tests/tools/gaussian_mixture/fit_gmm_pair_test.py
@@ -29,8 +29,9 @@ class TestFitGmmPair:
 
   @pytest.fixture(autouse=True)
   def initialize(self, rng: jax.Array):
-    mean_generator0 = jnp.array([[2., -1.], [-2., 0.], [4., 3.]])
-    cov_generator0 = jnp.array([[[0.2, 0.], [0., 0.1]], [[0.6, 0.], [0., 0.3]],
+    mean_generator0 = jnp.array([[2.0, -1.0], [-2.0, 0.0], [4.0, 3.0]])
+    cov_generator0 = jnp.array([[[0.2, 0.0], [0.0, 0.1]],
+                                [[0.6, 0.0], [0.0, 0.3]],
                                 [[0.5, 0.4], [0.4, 0.5]]])
     weights_generator0 = jnp.array([0.3, 0.3, 0.4])
 
@@ -43,10 +44,10 @@ class TestFitGmmPair:
     )
 
     # shift the means to the right by varying amounts
-    mean_generator1 = mean_generator0 + jnp.array([[1., -0.5], [-1., -1.],
-                                                   [-1., 0.]])
+    mean_generator1 = mean_generator0 + jnp.array([[1.0, -0.5], [-1.0, -1.0],
+                                                   [-1.0, 0.0]])
     cov_generator1 = cov_generator0
-    weights_generator1 = weights_generator0 + jnp.array([0., 0.1, -0.1])
+    weights_generator1 = weights_generator0 + jnp.array([0.0, 0.1, -0.1])
 
     gmm_generator1 = (
         gaussian_mixture.GaussianMixture.from_mean_cov_component_weights(
@@ -56,7 +57,7 @@ class TestFitGmmPair:
         )
     )
 
-    self.epsilon = 1.e-2
+    self.epsilon = 1e-2
     self.rho = 0.1
     self.tau = self.rho / (self.rho + self.epsilon)
 

--- a/tests/tools/gaussian_mixture/fit_gmm_test.py
+++ b/tests/tools/gaussian_mixture/fit_gmm_test.py
@@ -23,8 +23,9 @@ class TestFitGmm:
 
   @pytest.fixture(autouse=True)
   def initialize(self, rng: jax.Array):
-    mean_generator = jnp.array([[2., -1.], [-2., 0.], [4., 3.]])
-    cov_generator = jnp.array([[[0.2, 0.], [0., 0.1]], [[0.6, 0.], [0., 0.3]],
+    mean_generator = jnp.array([[2.0, -1.0], [-2.0, 0.0], [4.0, 3.0]])
+    cov_generator = jnp.array([[[0.2, 0.0], [0.0, 0.1]], [[0.6, 0.0],
+                                                          [0.0, 0.3]],
                                [[0.5, 0.4], [0.4, 0.5]]])
     weights_generator = jnp.array([0.3, 0.3, 0.4])
 

--- a/tests/tools/gaussian_mixture/gaussian_mixture_pair_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_mixture_pair_test.py
@@ -24,7 +24,7 @@ class TestGaussianMixturePair:
   def initialize(self, rng: jax.Array):
     self.n_components = 3
     self.n_dimensions = 2
-    self.epsilon = 1.e-3
+    self.epsilon = 1e-3
     self.rho = 0.1
     self.tau = self.rho / (self.rho + self.epsilon)
     self.rng, subrng0, subrng1 = jax.random.split(rng, num=3)
@@ -39,7 +39,7 @@ class TestGaussianMixturePair:
         n_dimensions=self.n_dimensions
     )
     self.balanced_pair = gaussian_mixture_pair.GaussianMixturePair(
-        gmm0=self.gmm0, gmm1=self.gmm1, epsilon=self.epsilon, tau=1.
+        gmm0=self.gmm0, gmm1=self.gmm1, epsilon=self.epsilon, tau=1.0
     )
     self.unbalanced_pair = gaussian_mixture_pair.GaussianMixturePair(
         gmm0=self.gmm0, gmm1=self.gmm1, epsilon=self.epsilon, tau=self.tau
@@ -59,7 +59,7 @@ class TestGaussianMixturePair:
         gmm0=gmm,
         gmm1=gmm,  # use same GMM for both gmm0 and gmm1
         epsilon=self.epsilon,
-        tau=1.
+        tau=1.0
     )
     cost_matrix = pair.get_cost_matrix()
     sinkhorn_output = pair.get_sinkhorn(cost_matrix=cost_matrix)
@@ -70,7 +70,7 @@ class TestGaussianMixturePair:
   @pytest.mark.fast()
   def test_get_sinkhorn_to_shifted_is_almost_shift(self):
     loc_shift = jnp.stack([
-        2. * jnp.ones(self.n_components),
+        2.0 * jnp.ones(self.n_components),
         jnp.zeros(self.n_components)
     ],
                           axis=-1)
@@ -80,7 +80,7 @@ class TestGaussianMixturePair:
         component_weight_ob=self.gmm0.component_weight_ob
     )
     pair = gaussian_mixture_pair.GaussianMixturePair(
-        gmm0=self.gmm0, gmm1=gmm1, epsilon=self.epsilon, tau=1.
+        gmm0=self.gmm0, gmm1=gmm1, epsilon=self.epsilon, tau=1.0
     )
     cost_matrix = pair.get_cost_matrix()
     sinkhorn_output = pair.get_sinkhorn(cost_matrix=cost_matrix)
@@ -95,7 +95,7 @@ class TestGaussianMixturePair:
         gmm0=gmm,
         gmm1=gmm,  # use same GMM for both gmm0 and gmm1
         epsilon=self.epsilon,
-        tau=1.
+        tau=1.0
     )
     cost_matrix = pair.get_cost_matrix()
     sinkhorn_output = pair.get_sinkhorn(cost_matrix=cost_matrix)
@@ -108,7 +108,7 @@ class TestGaussianMixturePair:
 
   def test_get_coupling_to_shifted(self):
     loc_shift = jnp.stack([
-        2. * jnp.ones(self.n_components),
+        2.0 * jnp.ones(self.n_components),
         jnp.zeros(self.n_components)
     ],
                           axis=-1)
@@ -118,7 +118,7 @@ class TestGaussianMixturePair:
         component_weight_ob=self.gmm0.component_weight_ob
     )
     pair = gaussian_mixture_pair.GaussianMixturePair(
-        gmm0=self.gmm0, gmm1=gmm1, epsilon=self.epsilon, tau=1.
+        gmm0=self.gmm0, gmm1=gmm1, epsilon=self.epsilon, tau=1.0
     )
     cost_matrix = pair.get_cost_matrix()
     sinkhorn_output = pair.get_sinkhorn(cost_matrix=cost_matrix)
@@ -166,11 +166,11 @@ class TestGaussianMixturePair:
         tau=tau,
         lock_gmm1=lock_gmm1
     )
-    expected_gmm1_loc = 2. * self.gmm1.loc if not lock_gmm1 else self.gmm1.loc
+    expected_gmm1_loc = 2.0 * self.gmm1.loc if not lock_gmm1 else self.gmm1.loc
 
-    pair_x_2 = jax.tree_map(lambda x: 2 * x, pair)
+    pair_x_2 = jax.tree_map(lambda x: 2.9 * x, pair)
     # gmm parameters should be doubled
-    np.testing.assert_allclose(2. * pair.gmm0.loc, pair_x_2.gmm0.loc)
+    np.testing.assert_allclose(2.0 * pair.gmm0.loc, pair_x_2.gmm0.loc)
     np.testing.assert_allclose(expected_gmm1_loc, pair_x_2.gmm1.loc)
     # epsilon and tau should not
     assert pair.epsilon == pair_x_2.epsilon

--- a/tests/tools/gaussian_mixture/gaussian_mixture_pair_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_mixture_pair_test.py
@@ -168,7 +168,7 @@ class TestGaussianMixturePair:
     )
     expected_gmm1_loc = 2.0 * self.gmm1.loc if not lock_gmm1 else self.gmm1.loc
 
-    pair_x_2 = jax.tree_map(lambda x: 2.9 * x, pair)
+    pair_x_2 = jax.tree_map(lambda x: 2.0 * x, pair)
     # gmm parameters should be doubled
     np.testing.assert_allclose(2.0 * pair.gmm0.loc, pair_x_2.gmm0.loc)
     np.testing.assert_allclose(expected_gmm1_loc, pair_x_2.gmm1.loc)

--- a/tests/tools/gaussian_mixture/gaussian_mixture_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_mixture_test.py
@@ -26,14 +26,14 @@ class TestGaussianMixture:
   ):
     n = 50
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    points0 = jax.random.normal(key=subrng0, shape=(n, 2))
+    points0 = jax.random.normal(subrng0, shape=(n, 2))
     points1 = (
-        2. * jax.random.normal(key=subrng1, shape=(n, 2)) + jnp.array([6., 8.])
+        2. * jax.random.normal(subrng1, shape=(n, 2)) + jnp.array([6., 8.])
     )
     points = jnp.concatenate([points0, points1], axis=0)
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    weights0 = jax.random.uniform(key=subrng0, shape=(n,))
-    weights1 = jax.random.uniform(key=subrng1, shape=(n,))
+    weights0 = jax.random.uniform(subrng0, shape=(n,))
+    weights1 = jax.random.uniform(subrng1, shape=(n,))
     weights = jnp.concatenate([weights0, weights1], axis=0)
     aprobs0 = jnp.stack([jnp.ones((n,)), jnp.zeros((n,))], axis=-1)
     aprobs1 = jnp.stack([jnp.zeros((n,)), jnp.ones((n,))], axis=-1)

--- a/tests/tools/gaussian_mixture/gaussian_mixture_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_mixture_test.py
@@ -28,7 +28,7 @@ class TestGaussianMixture:
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
     points0 = jax.random.normal(subrng0, shape=(n, 2))
     points1 = (
-        2. * jax.random.normal(subrng1, shape=(n, 2)) + jnp.array([6., 8.])
+        2.0 * jax.random.normal(subrng1, shape=(n, 2)) + jnp.array([6.0, 8.0])
     )
     points = jnp.concatenate([points0, points1], axis=0)
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
@@ -62,9 +62,9 @@ class TestGaussianMixture:
     np.testing.assert_array_equal([gmm.n_components, gmm.n_dimensions], (3, 2))
 
   def test_from_mean_cov_component_weights(self,):
-    mean = jnp.array([[1., 2], [3., 4.], [5, 6.]])
-    cov = jnp.array([[[1., 0.], [0., 2.]], [[3., 0.], [0., 4.]],
-                     [[5., 0.], [0., 6.]]])
+    mean = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    cov = jnp.array([[[1.0, 0.0], [0.0, 2.0]], [[3.0, 0.0], [0.0, 4.0]],
+                     [[5.0, 0.0], [0.0, 6.0]]])
     comp_wts = jnp.array([0.2, 0.3, 0.5])
     gmm = gaussian_mixture.GaussianMixture.from_mean_cov_component_weights(
         mean=mean, cov=cov, component_weights=comp_wts
@@ -90,24 +90,24 @@ class TestGaussianMixture:
 
   def test_sample(self, rng: jax.Array):
     gmm = gaussian_mixture.GaussianMixture.from_mean_cov_component_weights(
-        mean=jnp.array([[-1., 0.], [1., 0.]]),
-        cov=jnp.array([[[0.01, 0.], [0., 0.01]], [[0.01, 0.], [0., 0.01]]]),
+        mean=jnp.array([[-1.0, 0.0], [1.0, 0.0]]),
+        cov=jnp.array([[[0.01, 0.0], [0.0, 0.01]], [[0.01, 0.0], [0.0, 0.01]]]),
         component_weights=jnp.array([0.2, 0.8])
     )
     samples = gmm.sample(rng=rng, size=10000)
-    frac_pos = jnp.mean(samples[:, 0] > 0.)
+    frac_pos = jnp.mean(samples[:, 0] > 0.0)
 
     np.testing.assert_array_equal(samples.shape, (10000, 2))
     np.testing.assert_allclose(frac_pos, 0.8, atol=0.015)
     np.testing.assert_allclose(
-        jnp.mean(samples[samples[:, 0] > 0.], axis=0),
-        jnp.array([1., 0.]),
-        atol=1.e-2
+        jnp.mean(samples[samples[:, 0] > 0.0], axis=0),
+        jnp.array([1.0, 0.0]),
+        atol=1e-2
     )
     np.testing.assert_allclose(
-        jnp.mean(samples[samples[:, 0] < 0.], axis=0),
-        jnp.array([-1., 0.]),
-        atol=1.e-1
+        jnp.mean(samples[samples[:, 0] < 0.0], axis=0),
+        jnp.array([-1.0, 0.0]),
+        atol=1e-1
     )
 
   def test_log_prob(self, rng: jax.Array):
@@ -118,8 +118,8 @@ class TestGaussianMixture:
         rng=subrng0,
         n_components=3,
         n_dimensions=2,
-        stdev_mean=1.,
-        stdev_cov=1.,
+        stdev_mean=1.0,
+        stdev_cov=1.0,
         stdev_weights=1
     )
     x = gmm.sample(rng=subrng1, size=size)
@@ -161,13 +161,13 @@ class TestGaussianMixture:
     gmm = gaussian_mixture.GaussianMixture.from_random(
         rng=rng, n_components=3, n_dimensions=2
     )
-    gmm_x_2 = jax.tree_map(lambda x: 2 * x, gmm)
-    np.testing.assert_allclose(2. * gmm.loc, gmm_x_2.loc, atol=1e-4, rtol=1e-4)
+    gmm_x_2 = jax.tree_map(lambda x: 2.0 * x, gmm)
+    np.testing.assert_allclose(2.0 * gmm.loc, gmm_x_2.loc, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(
-        2. * gmm.scale_params, gmm_x_2.scale_params, atol=1e-4, rtol=1e-4
+        2.0 * gmm.scale_params, gmm_x_2.scale_params, atol=1e-4, rtol=1e-4
     )
     np.testing.assert_allclose(
-        2. * gmm.component_weight_ob.params,
+        2.0 * gmm.component_weight_ob.params,
         gmm_x_2.component_weight_ob.params,
         atol=1e-4,
         rtol=1e-4

--- a/tests/tools/gaussian_mixture/gaussian_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_test.py
@@ -28,8 +28,8 @@ class TestGaussian:
     np.testing.assert_array_equal(g.covariance().shape, (3, 3))
 
   def test_from_mean_and_cov(self):
-    mean = jnp.array([1., 2., 3.])
-    cov = jnp.diag(jnp.array([4., 5., 6.]))
+    mean = jnp.array([1.0, 2.0, 3.0])
+    cov = jnp.diag(jnp.array([4.0, 5.0, 6.0]))
     g = gaussian.Gaussian.from_mean_and_cov(mean=mean, cov=cov)
 
     np.testing.assert_array_equal(mean, g.loc)
@@ -37,9 +37,9 @@ class TestGaussian:
 
   def test_to_z(self, rng: jax.Array):
     g = gaussian.Gaussian(
-        loc=jnp.array([1., 2.]),
+        loc=jnp.array([1.0, 2.0]),
         scale=scale_tril.ScaleTriL(
-            params=jnp.array([0., 0.25, jnp.log(0.5)]), size=2
+            params=jnp.array([0.0, 0.25, jnp.log(0.5)]), size=2
         )
     )
     samples = g.sample(rng=rng, size=1000)
@@ -53,9 +53,9 @@ class TestGaussian:
 
   def test_from_z(self, rng: jax.Array):
     g = gaussian.Gaussian(
-        loc=jnp.array([0., 0.]),
+        loc=jnp.array([0.0, 0.0]),
         scale=scale_tril.ScaleTriL(
-            params=jnp.array([jnp.log(2.), 0., 0.]), size=2
+            params=jnp.array([jnp.log(2.0), 0.0, 0.0]), size=2
         )
     )
     x = g.sample(rng=rng, size=100)
@@ -65,9 +65,9 @@ class TestGaussian:
 
   def test_log_prob(self, rng: jax.Array):
     g = gaussian.Gaussian(
-        loc=jnp.array([0., 0.]),
+        loc=jnp.array([0.0, 0.0]),
         scale=scale_tril.ScaleTriL(
-            params=jnp.array([jnp.log(2.), 0., 0.]), size=2
+            params=jnp.array([jnp.log(2.0), 0.0, 0.0]), size=2
         )
     )
     x = g.sample(rng=rng, size=100)
@@ -78,14 +78,14 @@ class TestGaussian:
     np.testing.assert_allclose(expected, actual, atol=1e-5, rtol=1e-5)
 
   def test_sample(self, rng: jax.Array):
-    mean = jnp.array([1., 2.])
-    cov = jnp.diag(jnp.array([1., 4.]))
+    mean = jnp.array([1.0, 2.0])
+    cov = jnp.diag(jnp.array([1.0, 4.0]))
     g = gaussian.Gaussian.from_mean_and_cov(mean, cov)
     samples = g.sample(rng=rng, size=10000)
     sample_mean = jnp.mean(samples, axis=0)
     sample_cov = jnp.cov(samples, rowvar=False)
 
-    np.testing.assert_allclose(sample_mean, mean, atol=3. * 2. / 100.)
+    np.testing.assert_allclose(sample_mean, mean, atol=3.0 * 2.0 / 100.0)
     np.testing.assert_allclose(sample_cov, cov, atol=2e-1)
 
   def test_w2_dist(self, rng: jax.Array):
@@ -93,7 +93,7 @@ class TestGaussian:
     rng, subrng = jax.random.split(rng)
     n = gaussian.Gaussian.from_random(rng=subrng, n_dimensions=3)
     w2 = n.w2_dist(n)
-    np.testing.assert_almost_equal(w2, 0., decimal=5)
+    np.testing.assert_almost_equal(w2, 0.0, decimal=5)
 
     # When covariances commute (e.g. if covariance is diagonal), have
     # distance between covariances = frobenius norm^2 of (delta cholesky), see
@@ -112,25 +112,25 @@ class TestGaussian:
         loc=loc1, scale=scale_tril.ScaleTriL.from_covariance(jnp.diag(diag1))
     )
     w2 = g0.w2_dist(g1)
-    delta_mean = jnp.sum((loc1 - loc0) ** 2., axis=-1)
-    delta_sigma = jnp.sum((jnp.sqrt(diag0) - jnp.sqrt(diag1)) ** 2.)
+    delta_mean = jnp.sum((loc1 - loc0) ** 2, axis=-1)
+    delta_sigma = jnp.sum((jnp.sqrt(diag0) - jnp.sqrt(diag1)) ** 2)
     expected = delta_mean + delta_sigma
     np.testing.assert_allclose(expected, w2, rtol=1e-6, atol=1e-6)
 
   def test_transport(self, rng: jax.Array):
-    diag0 = jnp.array([1.])
-    diag1 = jnp.array([4.])
+    diag0 = jnp.array([1.0])
+    diag1 = jnp.array([4.0])
     g0 = gaussian.Gaussian(
-        loc=jnp.array([0.]),
+        loc=jnp.array([0.0]),
         scale=scale_tril.ScaleTriL.from_covariance(jnp.diag(diag0))
     )
     g1 = gaussian.Gaussian(
-        loc=jnp.array([1.]),
+        loc=jnp.array([1.0]),
         scale=scale_tril.ScaleTriL.from_covariance(jnp.diag(diag1))
     )
     points = jax.random.normal(rng, shape=(10, 1))
     actual = g0.transport(dest=g1, points=points)
-    expected = 2. * points + 1.
+    expected = 2.0 * points + 1.0
     np.testing.assert_allclose(expected, actual, atol=1e-5, rtol=1e-5)
 
   def test_flatten_unflatten(self, rng: jax.Array):
@@ -144,5 +144,5 @@ class TestGaussian:
     g = gaussian.Gaussian.from_random(rng, n_dimensions=3)
     g_x_2 = jax.tree_map(lambda x: 2 * x, g)
 
-    np.testing.assert_allclose(2. * g.loc, g_x_2.loc)
-    np.testing.assert_allclose(2. * g.scale.params, g_x_2.scale.params)
+    np.testing.assert_allclose(2.0 * g.loc, g_x_2.loc)
+    np.testing.assert_allclose(2.0 * g.scale.params, g_x_2.scale.params)

--- a/tests/tools/gaussian_mixture/gaussian_test.py
+++ b/tests/tools/gaussian_mixture/gaussian_test.py
@@ -100,11 +100,11 @@ class TestGaussian:
     # https://djalil.chafai.net/blog/2010/04/30/wasserstein-distance-between-two-gaussians/  # noqa: E501
     size = 4
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    loc0 = jax.random.normal(key=subrng0, shape=(size,))
-    loc1 = jax.random.normal(key=subrng1, shape=(size,))
+    loc0 = jax.random.normal(subrng0, shape=(size,))
+    loc1 = jax.random.normal(subrng1, shape=(size,))
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    diag0 = jnp.exp(jax.random.normal(key=subrng0, shape=(size,)))
-    diag1 = jnp.exp(jax.random.normal(key=subrng1, shape=(size,)))
+    diag0 = jnp.exp(jax.random.normal(subrng0, shape=(size,)))
+    diag1 = jnp.exp(jax.random.normal(subrng1, shape=(size,)))
     g0 = gaussian.Gaussian(
         loc=loc0, scale=scale_tril.ScaleTriL.from_covariance(jnp.diag(diag0))
     )
@@ -128,7 +128,7 @@ class TestGaussian:
         loc=jnp.array([1.]),
         scale=scale_tril.ScaleTriL.from_covariance(jnp.diag(diag1))
     )
-    points = jax.random.normal(key=rng, shape=(10, 1))
+    points = jax.random.normal(rng, shape=(10, 1))
     actual = g0.transport(dest=g1, points=points)
     expected = 2. * points + 1.
     np.testing.assert_allclose(expected, actual, atol=1e-5, rtol=1e-5)

--- a/tests/tools/gaussian_mixture/linalg_test.py
+++ b/tests/tools/gaussian_mixture/linalg_test.py
@@ -91,7 +91,7 @@ class TestLinalg:
     for i in range(size):
       for j in range(size):
         if j > i:
-          m = m.at[..., i, j].set(0.)
+          m = m.at[..., i, j].set(0.0)
     m = jnp.array(m)
     flat = linalg.tril_to_flat(m)
 
@@ -121,8 +121,8 @@ class TestLinalg:
     inv_m = jnp.linalg.inv(m)
     msq = jnp.matmul(m, m)
     actual = linalg.matrix_powers(msq, powers=(0.5, -0.5))
-    np.testing.assert_allclose(m, actual[0], rtol=1.e-5)
-    np.testing.assert_allclose(inv_m, actual[1], rtol=1.e-4)
+    np.testing.assert_allclose(m, actual[0], rtol=1e-5)
+    np.testing.assert_allclose(inv_m, actual[1], rtol=1e-4)
 
   def test_invmatvectril(self, rng: jax.Array):
     rng, subrng = jax.random.split(rng)
@@ -135,7 +135,7 @@ class TestLinalg:
     inv_cholesky = jnp.linalg.inv(cholesky)
     expected = jnp.transpose(jnp.matmul(inv_cholesky, jnp.transpose(x)))
     actual = linalg.invmatvectril(m=cholesky, x=x, lower=True)
-    np.testing.assert_allclose(expected, actual, atol=1e-4, rtol=1.e-4)
+    np.testing.assert_allclose(expected, actual, atol=1e-4, rtol=1e-4)
 
   def test_get_random_orthogonal(self, rng: jax.Array):
     rng, subrng = jax.random.split(rng)

--- a/tests/tools/gaussian_mixture/linalg_test.py
+++ b/tests/tools/gaussian_mixture/linalg_test.py
@@ -22,7 +22,7 @@ from ott.tools.gaussian_mixture import linalg
 class TestLinalg:
 
   def test_get_mean_and_var(self, rng: jax.Array):
-    points = jax.random.normal(key=rng, shape=(10, 2))
+    points = jax.random.normal(rng, shape=(10, 2))
     weights = jnp.ones(10)
     expected_mean = jnp.mean(points, axis=0)
     expected_var = jnp.var(points, axis=0)
@@ -33,7 +33,7 @@ class TestLinalg:
     np.testing.assert_allclose(expected_var, actual_var, atol=1E-5, rtol=1E-5)
 
   def test_get_mean_and_var_nonuniform_weights(self, rng: jax.Array):
-    points = jax.random.normal(key=rng, shape=(10, 2))
+    points = jax.random.normal(rng, shape=(10, 2))
     weights = jnp.concatenate([jnp.ones(5), jnp.zeros(5)], axis=-1)
     expected_mean = jnp.mean(points[:5], axis=0)
     expected_var = jnp.var(points[:5], axis=0)
@@ -44,7 +44,7 @@ class TestLinalg:
     np.testing.assert_allclose(expected_var, actual_var, rtol=1e-6, atol=1e-6)
 
   def test_get_mean_and_cov(self, rng: jax.Array):
-    points = jax.random.normal(key=rng, shape=(10, 2))
+    points = jax.random.normal(rng, shape=(10, 2))
     weights = jnp.ones(10)
     expected_mean = jnp.mean(points, axis=0)
     expected_cov = jnp.cov(points, rowvar=False, bias=True)
@@ -55,7 +55,7 @@ class TestLinalg:
     np.testing.assert_allclose(expected_cov, actual_cov, atol=1e-5, rtol=1e-5)
 
   def test_get_mean_and_cov_nonuniform_weights(self, rng: jax.Array):
-    points = jax.random.normal(key=rng, shape=(10, 2))
+    points = jax.random.normal(rng, shape=(10, 2))
     weights = jnp.concatenate([jnp.ones(5), jnp.zeros(5)], axis=-1)
     expected_mean = jnp.mean(points[:5], axis=0)
     expected_cov = jnp.cov(points[:5], rowvar=False, bias=True)
@@ -67,7 +67,7 @@ class TestLinalg:
 
   def test_flat_to_tril(self, rng: jax.Array):
     size = 3
-    x = jax.random.normal(key=rng, shape=(5, 4, size * (size + 1) // 2))
+    x = jax.random.normal(rng, shape=(5, 4, size * (size + 1) // 2))
     m = linalg.flat_to_tril(x, size)
     # check size of m
     np.testing.assert_array_equal(m.shape, (5, 4, size, size))
@@ -87,7 +87,7 @@ class TestLinalg:
 
   def test_tril_to_flat(self, rng: jax.Array):
     size = 3
-    m = jax.random.normal(key=rng, shape=(5, 4, size, size))
+    m = jax.random.normal(rng, shape=(5, 4, size, size))
     for i in range(size):
       for j in range(size):
         if j > i:
@@ -104,7 +104,7 @@ class TestLinalg:
 
   def test_apply_to_diag(self, rng: jax.Array):
     size = 3
-    m = jax.random.normal(key=rng, shape=(5, 4, size, size))
+    m = jax.random.normal(rng, shape=(5, 4, size, size))
     mnew = linalg.apply_to_diag(m, jnp.exp)
     for i in range(size):
       for j in range(size):
@@ -115,7 +115,7 @@ class TestLinalg:
 
   def test_matrix_powers(self, rng: jax.Array):
     rng, subrng = jax.random.split(rng)
-    m = jax.random.normal(key=subrng, shape=(4, 4))
+    m = jax.random.normal(subrng, shape=(4, 4))
     m += jnp.swapaxes(m, axis1=-2, axis2=-1)  # symmetric
     m = jnp.matmul(m, m)  # symmetric, pos def
     inv_m = jnp.linalg.inv(m)
@@ -126,12 +126,12 @@ class TestLinalg:
 
   def test_invmatvectril(self, rng: jax.Array):
     rng, subrng = jax.random.split(rng)
-    m = jax.random.normal(key=subrng, shape=(2, 2))
+    m = jax.random.normal(subrng, shape=(2, 2))
     m += jnp.swapaxes(m, axis1=-2, axis2=-1)  # symmetric
     m = jnp.matmul(m, m)  # symmetric, pos def
     cholesky = jnp.linalg.cholesky(m)  # lower triangular
     rng, subrng = jax.random.split(rng)
-    x = jax.random.normal(key=subrng, shape=(10, 2))
+    x = jax.random.normal(subrng, shape=(10, 2))
     inv_cholesky = jnp.linalg.inv(cholesky)
     expected = jnp.transpose(jnp.matmul(inv_cholesky, jnp.transpose(x)))
     actual = linalg.invmatvectril(m=cholesky, x=x, lower=True)

--- a/tests/tools/gaussian_mixture/probabilities_test.py
+++ b/tests/tools/gaussian_mixture/probabilities_test.py
@@ -22,21 +22,21 @@ from ott.tools.gaussian_mixture import probabilities
 class TestProbabilities:
 
   def test_probs(self):
-    pp = probabilities.Probabilities(jnp.array([1., 2.]))
+    pp = probabilities.Probabilities(jnp.array([1.0, 2.0]))
     probs = pp.probs()
     np.testing.assert_array_equal(probs.shape, (3,))
     np.testing.assert_allclose(jnp.sum(probs), 1.0, rtol=1e-6, atol=1e-6)
-    np.testing.assert_array_equal(probs > 0., True)
+    np.testing.assert_array_equal(probs > 0.0, True)
 
   def test_log_probs(self):
-    pp = probabilities.Probabilities(jnp.array([1., 2.]))
+    pp = probabilities.Probabilities(jnp.array([1.0, 2.0]))
     log_probs = pp.log_probs()
     probs = jnp.exp(log_probs)
 
     np.testing.assert_array_equal(log_probs.shape, (3,))
     np.testing.assert_array_equal(probs.shape, (3,))
     np.testing.assert_allclose(jnp.sum(probs), 1.0, rtol=1e-6, atol=1e-6)
-    np.testing.assert_array_equal(probs > 0., True)
+    np.testing.assert_array_equal(probs > 0.0, True)
 
   def test_from_random(self, rng: jax.Array):
     n_dimensions = 4
@@ -52,11 +52,11 @@ class TestProbabilities:
 
   def test_sample(self, rng: jax.Array):
     p = 0.4
-    probs = jnp.array([p, 1. - p])
+    probs = jnp.array([p, 1.0 - p])
     pp = probabilities.Probabilities.from_probs(probs)
-    samples = pp.sample(rng=rng, size=10000)
-    sd = jnp.sqrt(p * (1. - p))
-    np.testing.assert_allclose(jnp.mean(samples == 0), p, atol=3. * sd)
+    samples = pp.sample(rng, size=10000)
+    sd = jnp.sqrt(p * (1.0 - p))
+    np.testing.assert_allclose(jnp.mean(samples == 0.0), p, atol=3.0 * sd)
 
   def test_flatten_unflatten(self):
     probs = jnp.array([0.1, 0.2, 0.3, 0.4])
@@ -71,5 +71,5 @@ class TestProbabilities:
     pp = probabilities.Probabilities.from_probs(probs)
     pp_x_2 = jax.tree_map(lambda x: 2 * x, pp)
     np.testing.assert_allclose(
-        2. * pp.params, pp_x_2.params, rtol=1e-6, atol=1e-6
+        2.0 * pp.params, pp_x_2.params, rtol=1e-6, atol=1e-6
     )

--- a/tests/tools/gaussian_mixture/scale_tril_test.py
+++ b/tests/tools/gaussian_mixture/scale_tril_test.py
@@ -76,8 +76,8 @@ class TestScaleTriL:
     # see https://djalil.chafai.net/blog/2010/04/30/wasserstein-distance-between-two-gaussians/  # noqa: E501
     size = 4
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    diag0 = jnp.exp(jax.random.normal(key=subrng0, shape=(size,)))
-    diag1 = jnp.exp(jax.random.normal(key=subrng1, shape=(size,)))
+    diag0 = jnp.exp(jax.random.normal(subrng0, shape=(size,)))
+    diag1 = jnp.exp(jax.random.normal(subrng1, shape=(size,)))
     s0 = scale_tril.ScaleTriL.from_covariance(jnp.diag(diag0))
     s1 = scale_tril.ScaleTriL.from_covariance(jnp.diag(diag1))
     w2 = s0.w2_dist(s1)
@@ -87,13 +87,13 @@ class TestScaleTriL:
   def test_transport(self, rng: jax.Array):
     size = 4
     rng, subrng0, subrng1 = jax.random.split(rng, num=3)
-    diag0 = jnp.exp(jax.random.normal(key=subrng0, shape=(size,)))
+    diag0 = jnp.exp(jax.random.normal(subrng0, shape=(size,)))
     s0 = scale_tril.ScaleTriL.from_covariance(jnp.diag(diag0))
-    diag1 = jnp.exp(jax.random.normal(key=subrng1, shape=(size,)))
+    diag1 = jnp.exp(jax.random.normal(subrng1, shape=(size,)))
     s1 = scale_tril.ScaleTriL.from_covariance(jnp.diag(diag1))
 
     rng, subrng = jax.random.split(rng)
-    x = jax.random.normal(key=subrng, shape=(100, size))
+    x = jax.random.normal(subrng, shape=(100, size))
     transported = s0.transport(s1, points=x)
     expected = x * jnp.sqrt(diag1)[None] / jnp.sqrt(diag0)[None]
     np.testing.assert_allclose(expected, transported, atol=1e-4, rtol=1e-4)

--- a/tests/tools/gaussian_mixture/scale_tril_test.py
+++ b/tests/tools/gaussian_mixture/scale_tril_test.py
@@ -21,7 +21,7 @@ from ott.tools.gaussian_mixture import scale_tril
 
 @pytest.fixture()
 def chol() -> scale_tril.ScaleTriL:
-  params = jnp.array([0., 2., jnp.log(3.)])
+  params = jnp.array([0.0, 2.0, jnp.log(3.0)])
   return scale_tril.ScaleTriL(params=params, size=2)
 
 
@@ -29,11 +29,11 @@ def chol() -> scale_tril.ScaleTriL:
 class TestScaleTriL:
 
   def test_cholesky(self, chol: scale_tril.ScaleTriL):
-    expected = jnp.array([[1., 0.], [2., 3.]])
+    expected = jnp.array([[1.0, 0.0], [2.0, 3.0]])
     np.testing.assert_allclose(chol.cholesky(), expected, atol=1e-4, rtol=1e-4)
 
   def test_covariance(self, chol: scale_tril.ScaleTriL):
-    expected = jnp.array([[1., 0.], [2., 3.]])
+    expected = jnp.array([[1.0, 0.0], [2.0, 3.0]])
     np.testing.assert_allclose(chol.covariance(), expected @ expected.T)
 
   def test_covariance_sqrt(self, chol: scale_tril.ScaleTriL):
@@ -58,7 +58,7 @@ class TestScaleTriL:
   def test_from_cholesky(self, rng: jax.Array):
     n_dimensions = 4
     cholesky = scale_tril.ScaleTriL.from_random(
-        rng=rng, n_dimensions=n_dimensions, stdev=1.
+        rng=rng, n_dimensions=n_dimensions, stdev=1.0
     ).cholesky()
     scale = scale_tril.ScaleTriL.from_cholesky(cholesky)
     np.testing.assert_allclose(cholesky, scale.cholesky(), atol=1e-4, rtol=1e-4)
@@ -68,7 +68,7 @@ class TestScaleTriL:
     rng, subrng = jax.random.split(rng)
     s = scale_tril.ScaleTriL.from_random(rng=subrng, n_dimensions=3)
     w2 = s.w2_dist(s)
-    expected = 0.
+    expected = 0.0
     np.testing.assert_allclose(expected, w2, atol=1e-4, rtol=1e-4)
 
     # When covariances commute (e.g. if covariance is diagonal), have
@@ -81,7 +81,7 @@ class TestScaleTriL:
     s0 = scale_tril.ScaleTriL.from_covariance(jnp.diag(diag0))
     s1 = scale_tril.ScaleTriL.from_covariance(jnp.diag(diag1))
     w2 = s0.w2_dist(s1)
-    delta_sigma = jnp.sum((jnp.sqrt(diag0) - jnp.sqrt(diag1)) ** 2.)
+    delta_sigma = jnp.sum((jnp.sqrt(diag0) - jnp.sqrt(diag1)) ** 2)
     np.testing.assert_allclose(delta_sigma, w2, atol=1e-4, rtol=1e-4)
 
   def test_transport(self, rng: jax.Array):
@@ -108,4 +108,4 @@ class TestScaleTriL:
   def test_pytree_mapping(self, rng: jax.Array):
     scale = scale_tril.ScaleTriL.from_random(rng=rng, n_dimensions=3)
     scale_x_2 = jax.tree_map(lambda x: 2 * x, scale)
-    np.testing.assert_allclose(2. * scale.params, scale_x_2.params)
+    np.testing.assert_allclose(2.0 * scale.params, scale_x_2.params)

--- a/tests/tools/k_means_test.py
+++ b/tests/tools/k_means_test.py
@@ -135,7 +135,7 @@ class TestKmeans:
 
     assert res.centroids.shape == (k, ndim)
     assert res.converged
-    assert res.error >= 0.
+    assert res.error >= 0.0
     assert res.inner_errors is None
     assert _is_same_clustering(pred_assignment, gt_assignment, k)
 
@@ -210,23 +210,23 @@ class TestKmeans:
 
     errors = res.inner_errors
     assert errors.shape == (max_iter,)
-    assert res.iteration == jnp.sum(errors > 0.)
+    assert res.iteration == jnp.sum(errors > 0.0)
     # check if error is decreasing
-    np.testing.assert_array_equal(jnp.diff(errors[::-1]) >= 0., True)
+    np.testing.assert_array_equal(jnp.diff(errors[::-1]) >= 0.0, True)
 
   def test_strict_tolerance(self, rng: jax.Array):
     k = 11
     geom, _, _ = make_blobs(n_samples=200, centers=k, random_state=39)
 
-    res = k_means.k_means(geom, k=k, tol=1., rng=rng)
-    res_strict = k_means.k_means(geom, k=k, tol=0., rng=rng)
+    res = k_means.k_means(geom, k=k, tol=1.0, rng=rng)
+    res_strict = k_means.k_means(geom, k=k, tol=0.0, rng=rng)
 
     assert res.converged
     assert res_strict.converged
     assert res.iteration < res_strict.iteration
 
   @pytest.mark.parametrize(
-      "tol", [1e-3, 0.], ids=["weak-convergence", "strict-convergence"]
+      "tol", [1e-3, 0.0], ids=["weak-convergence", "strict-convergence"]
   )
   def test_convergence_force_scan(self, rng: jax.Array, tol: float):
     k, n_iter = 9, 20
@@ -256,7 +256,7 @@ class TestKmeans:
         store_inner_errors=True,
         min_iterations=min_iter,
         max_iterations=20,
-        tol=0.,
+        tol=0.0,
         rng=rng
     )
 
@@ -285,7 +285,7 @@ class TestKmeans:
 
   @pytest.mark.fast()
   def test_empty_weights(self, rng: jax.Array):
-    n, ndim, k, d = 20, 2, 3, 5.
+    n, ndim, k, d = 20, 2, 3, 5.0
     gen = np.random.RandomState(0)
     x = gen.normal(size=(n, ndim))
     x[:, 0] += d
@@ -301,7 +301,7 @@ class TestKmeans:
     w[:, 1] += d
     x = jnp.concatenate((x, y, z, w))
     # ignore `x` by setting its weights to 0
-    weights = jnp.ones((x.shape[0],)).at[:n].set(0.)
+    weights = jnp.ones((x.shape[0],)).at[:n].set(0.0)
 
     expected_centroids = jnp.stack([w.mean(0), z.mean(0), y.mean(0)])
     res = k_means.k_means(x, k=k, weights=weights, rng=rng)
@@ -312,12 +312,12 @@ class TestKmeans:
     np.testing.assert_array_equal(jnp.sort(ixs), jnp.arange(k))
 
     total_shift = jnp.sum(cost[jnp.arange(k), ixs])
-    np.testing.assert_allclose(total_shift, 0., rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(total_shift, 0.0, rtol=1e-3, atol=1e-3)
 
   def test_cosine_cost_fn(self):
     k = 4
     geom, _, _ = make_blobs(n_samples=75)
-    geom_scaled = pointcloud.PointCloud(geom * 10., cost_fn=costs.Cosine())
+    geom_scaled = pointcloud.PointCloud(geom * 10.0, cost_fn=costs.Cosine())
     geom = pointcloud.PointCloud(geom, cost_fn=costs.Cosine())
 
     res_scaled = k_means.k_means(geom_scaled, k=k)
@@ -400,7 +400,7 @@ class TestKmeans:
     actual = 2 * jnp.vdot(v_w, grad_w)
     np.testing.assert_allclose(actual, expected, rtol=tol, atol=tol)
 
-  @pytest.mark.parametrize("tol", [1e-3, 0.])
+  @pytest.mark.parametrize("tol", [1e-3, 0.0])
   @pytest.mark.parametrize(("n", "k"), [(37, 4), (128, 6)])
   def test_clustering_matches_sklearn(
       self, rng: jax.Array, n: int, k: int, tol: float

--- a/tests/tools/k_means_test.py
+++ b/tests/tools/k_means_test.py
@@ -141,7 +141,7 @@ class TestKmeans:
 
   @pytest.mark.fast()
   def test_k_means_simple_example(self):
-    expected_labels = np.asarray([1, 1, 0, 0], dtype=np.int32)
+    expected_labels = np.asarray([1, 1, 0, 0])
     expected_centers = np.asarray([[0.75, 1], [0.25, 0]])
 
     x = jnp.asarray([[0, 0], [0.5, 0], [0.5, 1], [1, 1]])

--- a/tests/tools/sinkhorn_divergence_test.py
+++ b/tests/tools/sinkhorn_divergence_test.py
@@ -432,5 +432,5 @@ class TestSinkhornDivergenceGrad:
     finite_diff_grad = (loss_delta_plus - loss_delta_minus) / (2 * eps)
 
     np.testing.assert_allclose(
-        custom_grad, finite_diff_grad, rtol=1e-02, atol=1e-02
+        custom_grad, finite_diff_grad, rtol=1e-2, atol=1e-2
     )

--- a/tests/tools/soft_sort_test.py
+++ b/tests/tools/soft_sort_test.py
@@ -108,7 +108,7 @@ class TestSoftSort:
     # Check passing custom sampler, must be still symmetric / centered on {.5}^d
     # Check passing custom epsilon also works.
     def ball_sampler(k: jax.Array, s: Tuple[int, int]) -> jnp.ndarray:
-      return 0.5 * (jax.random.ball(k, d=s[1], p=4, shape=(s[0],)) + 1.)
+      return 0.5 * (jax.random.ball(k, d=s[1], p=4, shape=(s[0],)) + 1.0)
 
     num_target_samples = 473
 
@@ -209,7 +209,7 @@ class TestSoftSort:
   @pytest.mark.parametrize("jit", [False, True])
   def test_quantiles(self, rng: jax.Array, jit: bool):
     inputs = jax.random.uniform(rng, (100, 2, 3))
-    q = jnp.array([.1, .8, .4])
+    q = jnp.array([0.1, 0.8, 0.4])
     quantile_fn = soft_sort.quantile
     if jit:
       quantile_fn = jax.jit(quantile_fn, static_argnames="axis")


### PR DESCRIPTION
Also removes explicit passing of the dtype and the deprecated `solve` function.
Fixes some warnings and minor pet-peeves (like missing leading/trailing 0s).