### PR TITLE
Update One_Sinkhorn.ipynb

### DIFF
--- a/docs/tutorials/One_Sinkhorn.ipynb
+++ b/docs/tutorials/One_Sinkhorn.ipynb
@@ -186,7 +186,7 @@
     "id": "Ay4guTHVDxRH"
    },
    "source": [
-    "When setting `epsilon` to `None`, the algorithms will default to $0.05$ of the mean distance described in the geometry. This is no magical number, but rather a simple statistic of the scale of the problem. We recommend that you tune `epsilon` by yourself, but using `None` might avoid common issues (such as running {class}`~ott.solvers.linear.sinkhorn.Sinkhorn` with a very small `epsilon` while the cost matrices are large)."
+    "When setting `epsilon` to `None`, the algorithms will default to $0.05$ of the mean cost described in the geometry. This is no magical number, but rather a simple statistic of the scale of the problem. We recommend that you tune `epsilon` by yourself, but using `None` might avoid common issues (such as running {class}`~ott.solvers.linear.sinkhorn.Sinkhorn` with a very small `epsilon` while the cost matrices are large)."
    ]
   },
   {


### PR DESCRIPTION
I think the description for calculating the default epsilon in this tutorial is inaccurate. The tutorial says that the algorithm sets the default $epsilon$ as "the mean distance described in the geometry".
However, looking into the code it seems to me that you're calculating the average of the cost matrix instead. For $\ell_2$ loss, this is twice the distance **squared**. For more complicated losses, this does not even have to be measure of distance.
I suggest we change this loss to "the mean cost described in the geometry" to avoid confusion.
