### PR TITLE
bug fix: avoid mixing up linear and quadratic in genot

### DIFF
--- a/src/ott/neural/methods/flows/genot.py
+++ b/src/ott/neural/methods/flows/genot.py
@@ -162,26 +162,25 @@ class GENOT:
 
     def prepare_data(
         batch: Dict[str, jnp.ndarray]
-    ) -> Tuple[Tuple[jnp.ndarray, Optional[jnp.ndarray], jnp.ndarray], Dict[
-        str, jnp.ndarray]]:
+    ) -> Tuple[Tuple[jnp.ndarray, Optional[jnp.ndarray], jnp.ndarray],
+               Tuple[jnp.ndarray, jnp.ndarray, Optional[jnp.ndarray],
+                     Optional[jnp.ndarray]]]:
       src_lin, src_quad = batch.get("src_lin"), batch.get("src_quad")
       tgt_lin, tgt_quad = batch.get("tgt_lin"), batch.get("tgt_quad")
       arrs = src_lin, tgt_lin, src_quad, tgt_quad
 
       if src_quad is None and tgt_quad is None:  # lin
         src, tgt = src_lin, tgt_lin
-        arrs_dict = {"x": src_lin, "y": tgt_lin}
+        arrs = src_lin, tgt_lin  # get rid of src_quad, tgt_quad args
       elif src_lin is None and tgt_lin is None:  # quad
         src, tgt = src_quad, tgt_quad
-        arrs_dict = {"xx": src_quad, "yy": tgt_quad}
       elif all(arr is not None for arr in arrs):  # fused quad
         src = jnp.concatenate([src_lin, src_quad], axis=1)
         tgt = jnp.concatenate([tgt_lin, tgt_quad], axis=1)
-        arrs_dict = {"x": src_lin, "y": tgt_lin, "xx": src_quad, "yy": tgt_quad}
       else:
         raise RuntimeError("Cannot infer OT problem type from data.")
 
-      return (src, batch.get("src_condition"), tgt), arrs_dict
+      return (src, batch.get("src_condition"), tgt), arrs
 
     rng = utils.default_prng_key(rng)
     training_logs = {"loss": []}
@@ -196,7 +195,7 @@ class GENOT:
       time = self.time_sampler(rng_time, n * self.n_samples_per_src)
       latent = self.latent_noise_fn(rng_noise, (n, self.n_samples_per_src))
 
-      tmat = self.data_match_fn(**matching_data)  # (n, m)
+      tmat = self.data_match_fn(*matching_data)  # (n, m)
       src_ixs, tgt_ixs = solver_utils.sample_conditional(  # (n, k), (m, k)
           rng_resample,
           tmat,

--- a/src/ott/neural/methods/flows/genot.py
+++ b/src/ott/neural/methods/flows/genot.py
@@ -53,7 +53,7 @@ class GENOT:
 
       - ``(src_lin, tgt_lin) -> matching`` - linear matching.
       - ``(src_quad, tgt_quad, src_lin, tgt_lin) -> matching`` -
-        quadratic (fused) GW matching. In the pure GW setting, btoh ``src_lin``
+        quadratic (fused) GW matching. In the pure GW setting, both ``src_lin``
         and ``tgt_lin`` will be set to :obj:`None`.
 
     source_dim: Dimensionality of the source distribution.

--- a/src/ott/solvers/utils.py
+++ b/src/ott/solvers/utils.py
@@ -59,10 +59,10 @@ def match_linear(
 
 
 def match_quadratic(
-    x: Optional[jnp.ndarray],
-    y: Optional[jnp.ndarray],
     xx: jnp.ndarray,
     yy: jnp.ndarray,
+    x: Optional[jnp.ndarray] = None,
+    y: Optional[jnp.ndarray] = None,
     scale_cost: ScaleCost_t = 1.0,
     cost_fn: Optional[costs.CostFn] = None,
     **kwargs: Any

--- a/src/ott/solvers/utils.py
+++ b/src/ott/solvers/utils.py
@@ -59,10 +59,10 @@ def match_linear(
 
 
 def match_quadratic(
+    x: Optional[jnp.ndarray],
+    y: Optional[jnp.ndarray],
     xx: jnp.ndarray,
     yy: jnp.ndarray,
-    x: Optional[jnp.ndarray] = None,
-    y: Optional[jnp.ndarray] = None,
     scale_cost: ScaleCost_t = 1.0,
     cost_fn: Optional[costs.CostFn] = None,
     **kwargs: Any

--- a/tests/neural/methods/genot_test.py
+++ b/tests/neural/methods/genot_test.py
@@ -32,7 +32,7 @@ def get_match_fn(typ: Literal["lin", "quad", "fused"]):
     return solver_utils.match_linear
   if typ == "quad":
     return solver_utils.match_quadratic
-  # typ == "fused":
+  # typ == "fused"
   return solver_utils.match_quadratic
 
 

--- a/tests/neural/methods/genot_test.py
+++ b/tests/neural/methods/genot_test.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
-from typing import Literal, Optional
+from typing import Literal
 
 import pytest
 
@@ -28,20 +27,13 @@ from ott.neural.networks import velocity_field
 from ott.solvers import utils as solver_utils
 
 
-def data_match_fn(
-    src_lin: Optional[jnp.ndarray], tgt_lin: Optional[jnp.ndarray],
-    src_quad: Optional[jnp.ndarray], tgt_quad: Optional[jnp.ndarray], *,
-    typ: Literal["lin", "quad", "fused"]
-) -> jnp.ndarray:
+def get_match_fn(typ: Literal["lin", "quad", "fused"]):
   if typ == "lin":
-    return solver_utils.match_linear(x=src_lin, y=tgt_lin)
+    return solver_utils.match_linear
   if typ == "quad":
-    return solver_utils.match_quadratic(xx=src_quad, yy=tgt_quad)
-  if typ == "fused":
-    return solver_utils.match_quadratic(
-        xx=src_quad, yy=tgt_quad, x=src_lin, y=tgt_lin
-    )
-  raise NotImplementedError(f"Unknown type: {typ}.")
+    return solver_utils.match_quadratic
+  # typ == "fused":
+  return solver_utils.match_quadratic
 
 
 class TestGENOT:
@@ -69,7 +61,7 @@ class TestGENOT:
     model = genot.GENOT(
         vf,
         flow=dynamics.ConstantNoiseFlow(0.0),
-        data_match_fn=functools.partial(data_match_fn, typ=problem_type),
+        data_match_fn=get_match_fn(typ=problem_type),
         source_dim=src_dim,
         target_dim=tgt_dim,
         condition_dim=cond_dim,

--- a/tests/neural/methods/genot_test.py
+++ b/tests/neural/methods/genot_test.py
@@ -32,8 +32,9 @@ def get_match_fn(typ: Literal["lin", "quad", "fused"]):
     return solver_utils.match_linear
   if typ == "quad":
     return solver_utils.match_quadratic
-  # typ == "fused"
-  return solver_utils.match_quadratic
+  if typ == "fused":
+    return solver_utils.match_quadratic
+  raise NotImplementedError(typ)
 
 
 class TestGENOT:
@@ -61,7 +62,7 @@ class TestGENOT:
     model = genot.GENOT(
         vf,
         flow=dynamics.ConstantNoiseFlow(0.0),
-        data_match_fn=get_match_fn(typ=problem_type),
+        data_match_fn=get_match_fn(problem_type),
         source_dim=src_dim,
         target_dim=tgt_dim,
         condition_dim=cond_dim,


### PR DESCRIPTION
This fixes [https://github.com/ott-jax/ott/issues/514](https://github.com/ott-jax/ott/issues/514).

`prepare_data()` now returns a dict with the right keys for the linear or quadratic matching function.