### PR TITLE
Fix/batched non sym cost

### DIFF
--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -301,7 +301,7 @@ class PointCloud(geometry.Geometry):
     return transport(
         self.x, self.y, self._norm_x, self._norm_y, f, g, self.epsilon,
         self.cost_fn, self.inv_scale_cost
-    )
+    ).T
 
   def transport_from_scalings(  # noqa: D102
       self, u: jnp.ndarray, v: jnp.ndarray
@@ -313,7 +313,7 @@ class PointCloud(geometry.Geometry):
     return transport(
         self.x, self.y, self._norm_x, self._norm_y, u, v, self.epsilon,
         self.cost_fn, self.inv_scale_cost
-    )
+    ).T
 
   def apply_cost(
       self,

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -244,7 +244,7 @@ class PointCloud(geometry.Geometry):
     )
 
     if axis == 0:
-      fun, cost_fn = body0, self.cost_fn
+      fun, cost_fn = body0, self.cost_fn.pairwise
       v, n = g, self._y_nsplit
     elif axis == 1:
       fun, cost_fn = body1, lambda y, x: self.cost_fn.pairwise(x, y)

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -199,12 +199,9 @@ class PointCloud(geometry.Geometry):
     def body0(carry, i: int):
       f, g, eps, vec = carry
       y, g_ = self._leading_slice(self.y, i), self._leading_slice(g, i)
-      if self._axis_norm is None:
-        norm_y = self._norm_y
-      else:
-        norm_y = jax.lax.dynamic_slice(
-            self._norm_y, (i * self.batch_size,), (self.batch_size,)
-        )
+      norm_y = self._norm_y if self._axis_norm is None else self._leading_slice(
+          self._norm_y, i
+      )
       h_res, h_sgn = app(
           self.x, y, self._norm_x, norm_y, f, g_, eps, vec, cost_fn,
           self.inv_scale_cost
@@ -214,12 +211,9 @@ class PointCloud(geometry.Geometry):
     def body1(carry, i: int):
       f, g, eps, vec = carry
       x, f_ = self._leading_slice(self.x, i), self._leading_slice(f, i)
-      if self._axis_norm is None:
-        norm_x = self._norm_x
-      else:
-        norm_x = jax.lax.dynamic_slice(
-            self._norm_x, (i * self.batch_size,), (self.batch_size,)
-        )
+      norm_x = self._norm_x if self._axis_norm is None else self._leading_slice(
+          self._norm_x, i
+      )
       h_res, h_sgn = app(
           self.y, x, self._norm_y, norm_x, g, f_, eps, vec, cost_fn,
           self.inv_scale_cost

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -298,10 +298,11 @@ class PointCloud(geometry.Geometry):
       return super().transport_from_potentials(f, g)
     in_axes = [None, 0, None, self._axis_norm, None, 0, None, None, None]
     transport = jax.vmap(_transport_from_potentials_xy, in_axes=in_axes)
+    cost_fn = lambda y, x: self.cost_fn.pairwise(x, y)
     return transport(
-        self.x, self.y, self._norm_x, self._norm_y, f, g, self.epsilon,
-        self.cost_fn, self.inv_scale_cost
-    ).T
+        self.y, self.x, self._norm_y, self._norm_x, g, f, self.epsilon, cost_fn,
+        self.inv_scale_cost
+    )
 
   def transport_from_scalings(  # noqa: D102
       self, u: jnp.ndarray, v: jnp.ndarray
@@ -310,10 +311,11 @@ class PointCloud(geometry.Geometry):
       return super().transport_from_scalings(u, v)
     in_axes = [None, 0, None, self._axis_norm, None, 0, None, None, None]
     transport = jax.vmap(_transport_from_scalings_xy, in_axes=in_axes)
+    cost_fn = lambda y, x: self.cost_fn.pairwise(x, y)
     return transport(
-        self.x, self.y, self._norm_x, self._norm_y, u, v, self.epsilon,
-        self.cost_fn, self.inv_scale_cost
-    ).T
+        self.y, self.x, self._norm_y, self._norm_x, v, u, self.epsilon, cost_fn,
+        self.inv_scale_cost
+    )
 
   def apply_cost(
       self,

--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -357,6 +357,7 @@ class PointCloud(geometry.Geometry):
     if not self.is_online:
       return super().apply_cost(arr, axis, fn)
 
+    # TODO(michalk8): batch this properly
     app = jax.vmap(
         _apply_cost_xy,
         in_axes=[None, 0, None, self._axis_norm, None, None, None, None]
@@ -366,11 +367,12 @@ class PointCloud(geometry.Geometry):
 
     if axis == 0:
       return app(
-          self.x, self.y, self._norm_x, self._norm_y, arr, self.cost_fn,
-          self.inv_scale_cost, fn
+          self.x, self.y, self._norm_x, self._norm_y, arr,
+          self.cost_fn.pairwise, self.inv_scale_cost, fn
       )
+    cost_fn = lambda y, x: self.cost_fn.pairwise(x, y)
     return app(
-        self.y, self.x, self._norm_y, self._norm_x, arr, self.cost_fn,
+        self.y, self.x, self._norm_y, self._norm_x, arr, cost_fn,
         self.inv_scale_cost, fn
     )
 

--- a/tests/geometry/pointcloud_test.py
+++ b/tests/geometry/pointcloud_test.py
@@ -204,3 +204,16 @@ class TestPointCloudCosineConversion:
         rtol=1e-6,
         atol=1e-6,
     )
+
+    np.testing.assert_allclose(
+        pc.mean_cost_matrix,
+        pc_batched._compute_summary_online("mean"),
+        rtol=1e-6,
+        atol=1e-6
+    )
+    np.testing.assert_allclose(
+        pc.cost_matrix.max(),
+        pc_batched._compute_summary_online("max_cost"),
+        rtol=1e-6,
+        atol=1e-6
+    )


### PR DESCRIPTION
Fixes wrong computation for non-symmetric costs. This bug was only present when `batch_size` was passed in the `PointCloud`.