### PR TITLE
Force ICNN to adopt default initialization of its own layers

### DIFF
--- a/src/ott/neural/networks/icnn.py
+++ b/src/ott/neural/networks/icnn.py
@@ -23,7 +23,7 @@ from ott.neural.networks.layers import posdef
 
 __all__ = ["ICNN"]
 
-DEFAULT_KERNEL_INIT = lambda *a, **k: nn.initializers.normal()(*a, **k)
+DEFAULT_KERNEL_INIT = posdef.DEFAULT_KERNEL_INIT
 DEFAULT_RECTIFIER = nn.activation.relu
 DEFAULT_ACTIVATION = nn.activation.relu
 


### PR DESCRIPTION
The ICNN used to rely on initialisation with `normal matrices`.  Now, it fallbacks to the behavior of the layers, i.e `lecun_normal`, which scales the standard deviation of the weights with `1/sqrt(fan_in)`. This `std` is much smaller for wide networks.   