### PR TITLE
correct convergence criterion for GW

### DIFF
--- a/src/ott/solvers/quadratic/gromov_wasserstein.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein.py
@@ -261,7 +261,8 @@ class GromovWasserstein(was_solver.WassersteinSolver):
     linear_state = out.linear_state.set_cost(linearization, True, True)
     iteration = jnp.sum(out.costs != -1)
     converged = jnp.logical_and(
-        iteration < self.max_iterations, jnp.all(out.linear_convergence)
+        iteration < self.max_iterations,
+        jnp.nanmean(out.linear_convergence) == 1.0
     )
     return out.set(
         linear_state=linear_state, geom=linearization.geom, converged=converged
@@ -294,7 +295,7 @@ class GromovWasserstein(was_solver.WassersteinSolver):
 
     return GWState(
         costs=-jnp.ones((num_iter,)),
-        linear_convergence=-jnp.ones((num_iter,)),
+        linear_convergence=jnp.zeros((num_iter,)) * jnp.nan,
         linear_state=linear_state,
         linear_pb=init,
         old_transport_mass=transport_mass,

--- a/src/ott/solvers/quadratic/gromov_wasserstein.py
+++ b/src/ott/solvers/quadratic/gromov_wasserstein.py
@@ -295,7 +295,7 @@ class GromovWasserstein(was_solver.WassersteinSolver):
 
     return GWState(
         costs=-jnp.ones((num_iter,)),
-        linear_convergence=jnp.zeros((num_iter,)) * jnp.nan,
+        linear_convergence=jnp.full((num_iter,), fill_value=jnp.nan),
         linear_state=linear_state,
         linear_pb=init,
         old_transport_mass=transport_mass,


### PR DESCRIPTION
Entropic GW convergence was testing 

```
jnp.logical_and(
        iteration < self.max_iterations, jnp.all(out.linear_convergence)
    )
```
This is wrong, because `out.linear_convergence` was allocated by default a vector of `max_iterations` values set at `-1`. Therefore, if the solver stops before `max_iterations`, the remaining entries were set at `-1` and the bool was necessarily `False` (note that given the first test above, when stopping at `max_iterations`, the value was also `False`).

The flag was therefore always `False`.

The modification proposes to populate instead with `Nan` values and check that `jnp.nanmean` is `1.0`.