### PR TITLE
expose `SinkhornDivergenceOutput`

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -26,6 +26,7 @@ Sinkhorn Divergence
     :toctree: _autosummary
 
     sinkhorn_divergence.sinkhorn_divergence
+    sinkhorn_divergence.SinkhornDivergenceOutput
     sinkhorn_divergence.segment_sinkhorn_divergence
 
 Sliced Wasserstein Distance

--- a/docs/tutorials/linear/400_Hessians.ipynb
+++ b/docs/tutorials/linear/400_Hessians.ipynb
@@ -98,7 +98,7 @@
     "        y,  # this part defines geometry\n",
     "        a=a,\n",
     "        b=b,  # this sets weights\n",
-    "        sinkhorn_kwargs={\n",
+    "        solve_kwargs={\n",
     "            \"implicit_diff\": imp_diff.ImplicitDiff() if implicit else None,\n",
     "            \"use_danskin\": False,\n",
     "        },\n",

--- a/src/ott/tools/progot.py
+++ b/src/ott/tools/progot.py
@@ -421,7 +421,7 @@ def _sinkhorn_divergence(
       cost_fn=cost_fn,
       epsilon=eps,
       share_epsilon=False,
-      sinkhorn_kwargs=kwargs,
+      solve_kwargs=kwargs,
   )
   return out
 

--- a/src/ott/tools/segment_sinkhorn.py
+++ b/src/ott/tools/segment_sinkhorn.py
@@ -37,29 +37,29 @@ def segment_sinkhorn(
     sinkhorn_kwargs: Mapping[str, Any] = MappingProxyType({}),
     **kwargs: Any
 ) -> jnp.ndarray:
-  """Compute regularized OT cost between subsets of vectors in `x` and `y`.
+  """Compute regularized OT cost between subsets of vectors in ``x`` and ``y``.
 
   Helper function designed to compute Sinkhorn regularized OT cost between
   several point clouds of varying size, in parallel, using padding.
-  In practice, The inputs `x` and `y` (and their weight vectors `weights_x` and
-  `weights_y`) are assumed to be large weighted point clouds, that describe
-  points taken from multiple measures. To extract several subsets of points, we
-  provide two interfaces. The first interface assumes that a vector of id's is
-  passed, describing for each point of `x` (resp. `y`) to which measure the
-  point belongs to. The second interface assumes that `x` and `y` were simply
-  formed by concatenating several measures contiguously, and that only indices
-  that segment these groups are needed to recover them.
+  In practice, The inputs ``x`` and ``y`` (and their weight vectors `weights_x`
+  and ``weights_y``) are assumed to be large weighted point clouds, that
+  describe points taken from multiple measures. To extract several subsets of
+  points, we provide two interfaces. The first interface assumes that a vector
+  of id's is passed, describing for each point of ``x`` (resp. ``y``) to which
+  measure the point belongs to. The second interface assumes that ``x`` and
+  ``y`` were simply formed by concatenating several measures contiguously, and
+  that only indices that segment these groups are needed to recover them.
 
-  For both interfaces, both `x` and `y` should contain the same total number of
-  segments. Each segment will be padded as necessary, all segments rearranged as
-  a tensor, and :func:`jax.vmap` used to evaluate Sinkhorn divergences in
+  For both interfaces, both ``x`` and ``y`` should contain the same total number
+  of segments. Each segment will be padded as necessary, all segments rearranged
+  as a tensor, and :func:`jax.vmap` used to evaluate Sinkhorn divergences in
   parallel.
 
   Args:
-    x: Array of input points, of shape `[num_x, feature]`.
+    x: Array of input points, of shape ``[num_x, dim]``.
       Multiple segments are held in this single array.
-    y: Array of target points, of shape `[num_y, feature]`.
-    num_segments: Number of segments contained in `x` and `y`.
+    y: Array of target points, of shape ``[num_y, dim]``.
+    num_segments: Number of segments contained in ``x``and ``y``.
       Providing this is required for JIT compilation to work,
       see also :func:`~ott.geometry.segment.segment_point_cloud`.
     max_measure_size: Total size of measures after padding. Should ideally be
@@ -74,22 +74,22 @@ def segment_sinkhorn(
     indices_are_sorted: **1st interface** Whether `segment_ids_x` and
       `segment_ids_y` are sorted.
     num_per_segment_x: **2nd interface** Number of points in each segment in
-      `x`. For example, [100, 20, 30] would imply that `x` is segmented into
-      three arrays of length `[100]`, `[20]`, and `[30]` respectively.
+      `x`. For example, ``[100, 20, 30]`` would imply that ``x``is segmented
+      into 3 arrays of length ``[100]``, ``[20]``, and ``[30]`` respectively.
     num_per_segment_y: **2nd interface** Number of points in each segment in
-      `y`.
+      ``y``.
     weights_x: Weights of each input points, arranged in the same segmented
-      order as `x`.
+      order as ``x``.
     weights_y: Weights of each input points, arranged in the same segmented
-      order as `y`.
+      order as ``y``.
     sinkhorn_kwargs: Optionally a dict containing the keywords arguments for
       calls for the :class:`~ott.solvers.linear.sinkhorn.Sinkhorn` solver,
       called three times to evaluate for each segment the Sinkhorn regularized
-      OT cost between `x`/`y`, `x`/`x`, and `y`/`y` (except when `static_b` is
-      `True`, in which case `y`/`y` is not evaluated).
+      OT cost between ``x``/``y``, ``x``/`x`, and `y`/``y`` (except when
+      ``static_b`` is ``True``, in which case ``y``/``y`` is not evaluated).
     kwargs: keywords arguments passed to form
       :class:`~ott.geometry.pointcloud.PointCloud` geometry objects from the
-      subsets of points and masses selected in `x` and `y`, possibly a
+      subsets of points and masses selected in ``x``and ``y``, possibly a
       :class:`~ott.geometry.costs.CostFn` or an entropy regularizer.
 
   Returns:

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -34,6 +34,30 @@ Factors = Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
 
 @utils.register_pytree_node
 class SinkhornDivergenceOutput:  # noqa: D101
+  r"""Holds the outputs of a call to :func:`sinkhorn_divergence`.
+
+  Objects of this class contain both solutions and problem definition of a
+  two or three regularized OT problem instantiated when computing a Sinkhorn
+  divergence between two probability distributions.
+
+  Args:
+    divergence: value of the Sinkhorn divergence
+    geoms: three geometries describing the Sinkhorn divergence, of respective
+      sizes :math:`n\times m, n\times n, m\times m`.
+    a: vector of marginal weights for first set.
+    b: vector of marginal weights for second set.
+    potentials: three pairs of potential vectors, of sizes
+      :math:`(n,n), (n,m), (m,m)`. Used when the solver used to compute the
+      divergence was vanilla Sinkhorn.
+    factors: three triplets of matrices, of sizes
+      :math:`((n,r), (m,r), (r,)), ((n,r),(n,r,), (r,)), ((m,r),(m,r,), (r,))`.
+      These are only returned when the solver used to compute the divergence was
+      low-rank Sinkhorn.
+    converged: triplet of bools indicating the convergence on each of the three
+      problems run to compute the divergence.
+    n_iters: number of iterations that were run for each of the three
+      computations
+  """
   divergence: float
   geoms: Tuple[geometry.Geometry, geometry.Geometry, geometry.Geometry]
   a: jnp.ndarray
@@ -46,7 +70,7 @@ class SinkhornDivergenceOutput:  # noqa: D101
   n_iters: Tuple[int, int, int]
 
   def to_dual_potentials(self) -> "potentials.EntropicPotentials":
-    """Return dual estimators :cite:`pooladian:22`, eq. 8."""
+    """Return dual potential functions, :cite:`pooladian:22`, Eq. 8."""
     assert not self.is_low_rank, \
       "Dual potentials are not available for low-rank."
     geom_xy, *_ = self.geoms
@@ -81,7 +105,7 @@ def sinkhorn_divergence(
     *args: Any,
     a: Optional[jnp.ndarray] = None,
     b: Optional[jnp.ndarray] = None,
-    sinkhorn_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    solve_kwargs: Mapping[str, Any] = MappingProxyType({}),
     static_b: bool = False,
     share_epsilon: bool = True,
     symmetric_sinkhorn: bool = True,
@@ -98,10 +122,10 @@ def sinkhorn_divergence(
       match that of `b` to converge.
     b: the weight of each target point. The sum of all elements of `b` must
       match that of `a` to converge.
-    sinkhorn_kwargs: keywords arguments for
-      :func:`~ott.solvers.linear.solve` that is called twice
-      if ``static_b = True`` else 3 times.
-    static_b: if True, divergence of measure `b` against itself is **not**
+    solve_kwargs: keywords arguments for
+      :func:`~ott.solvers.linear.solve` that is called either twice
+      if ``static_b == True`` or three times when ``static_b == False``.
+    static_b: if ``True``, divergence of measure `b` against itself is **not**
       computed.
     share_epsilon: if True, enforces that the same epsilon regularizer is shared
       for all 2 or 3 terms of the Sinkhorn divergence. In that case, the epsilon
@@ -136,7 +160,7 @@ def sinkhorn_divergence(
       a=a,
       b=b,
       symmetric_sinkhorn=symmetric_sinkhorn,
-      **sinkhorn_kwargs
+      **solve_kwargs
   )
   return out.divergence, out
 
@@ -247,7 +271,7 @@ def segment_sinkhorn_divergence(
     num_per_segment_y: Optional[Tuple[int, ...]] = None,
     weights_x: Optional[jnp.ndarray] = None,
     weights_y: Optional[jnp.ndarray] = None,
-    sinkhorn_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    solve_kwargs: Mapping[str, Any] = MappingProxyType({}),
     static_b: bool = False,
     share_epsilon: bool = True,
     symmetric_sinkhorn: bool = False,
@@ -298,7 +322,7 @@ def segment_sinkhorn_divergence(
       order as `x`.
     weights_y: Weights of each input points, arranged in the same segmented
       order as `y`.
-    sinkhorn_kwargs: Optionally a dict containing the keywords arguments for
+    solve_kwargs: Optionally a dict containing the keywords arguments for
       calls to the `sinkhorn` function, called three times to evaluate for each
       segment the Sinkhorn regularized OT cost between `x`/`y`, `x`/`x`, and
       `y`/`y` (except when `static_b` is `True`, in which case `y`/`y` is not
@@ -342,7 +366,7 @@ def segment_sinkhorn_divergence(
         padded_y,
         a=padded_weight_x,
         b=padded_weight_y,
-        sinkhorn_kwargs=sinkhorn_kwargs,
+        solve_kwargs=solve_kwargs,
         static_b=static_b,
         share_epsilon=share_epsilon,
         symmetric_sinkhorn=symmetric_sinkhorn,

--- a/src/ott/tools/sinkhorn_divergence.py
+++ b/src/ott/tools/sinkhorn_divergence.py
@@ -70,7 +70,14 @@ class SinkhornDivergenceOutput:  # noqa: D101
   n_iters: Tuple[int, int, int]
 
   def to_dual_potentials(self) -> "potentials.EntropicPotentials":
-    """Return dual potential functions, :cite:`pooladian:22`, Eq. 8."""
+    """Return dual potential functions, :cite:`pooladian:22`.
+
+    Using vectors stored in ``potentials``, instantiate a
+    :class:`~ott.problems.linear.potentials.EntropicPotentials` object that will
+    provide approximations to optimal dual potential functions for the dual
+    OT problem defined for the geometry stored in ``geoms[0]``. These correspond
+    to Equation 8 in :cite:`pooladian:22`.
+    """
     assert not self.is_low_rank, \
       "Dual potentials are not available for low-rank."
     geom_xy, *_ = self.geoms

--- a/tests/tools/sinkhorn_divergence_test.py
+++ b/tests/tools/sinkhorn_divergence_test.py
@@ -59,7 +59,7 @@ class TestSinkhornDivergence:
           a=self._a,
           b=self._b,
           epsilon=epsilon,
-          sinkhorn_kwargs={"rank": rank},
+          solve_kwargs={"rank": rank},
       )
 
     is_low_rank = rank > 0
@@ -113,7 +113,7 @@ class TestSinkhornDivergence:
         x,
         cost_fn=cost_fn,
         epsilon=1e-1,
-        sinkhorn_kwargs={
+        solve_kwargs={
             "inner_iterations": 1,
             "threshold": 1e-5,
             "rank": rank,
@@ -139,7 +139,7 @@ class TestSinkhornDivergence:
         cloud_b,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs={"threshold": 1e-2},
+        solve_kwargs={"threshold": 1e-2},
     )
     assert div > 0.0
     assert len(out.potentials) == 3
@@ -156,7 +156,7 @@ class TestSinkhornDivergence:
         cloud_b,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs={"threshold": 1e-2},
+        solve_kwargs={"threshold": 1e-2},
         share_epsilon=False
     )
     assert jnp.abs(out.geoms[0].epsilon - out.geoms[1].epsilon) > 0
@@ -171,7 +171,7 @@ class TestSinkhornDivergence:
         cloud_a,
         cloud_b,
         epsilon=0.1,
-        sinkhorn_kwargs={
+        solve_kwargs={
             "threshold": 1e-2,
             "tau_a": 0.8,
             "tau_b": 0.9
@@ -199,7 +199,7 @@ class TestSinkhornDivergence:
         epsilon=0.1,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs={"threshold": 1e-2},
+        solve_kwargs={"threshold": 1e-2},
     )
     assert div > 0.0
     assert len(out.potentials) == 3
@@ -213,7 +213,7 @@ class TestSinkhornDivergence:
         epsilon=0.1,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs={"threshold": 1e-2},
+        solve_kwargs={"threshold": 1e-2},
     )
     assert div > 0.0
     assert len(out.potentials) == 3
@@ -226,7 +226,7 @@ class TestSinkhornDivergence:
         epsilon=0.1,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs={"threshold": 1e-2},
+        solve_kwargs={"threshold": 1e-2},
     )
     assert div > 0.0
     assert len(out.potentials) == 3
@@ -239,14 +239,14 @@ class TestSinkhornDivergence:
     x = jax.random.uniform(rngs[0], (self._num_points[0], self._dim))
     y = jax.random.uniform(rngs[1], (self._num_points[1], self._dim))
     geom_kwargs = {"epsilon": 0.01}
-    sinkhorn_kwargs = {"threshold": 1e-2}
+    solve_kwargs = {"threshold": 1e-2}
     true_divergence, _ = sinkhorn_divergence.sinkhorn_divergence(
         pointcloud.PointCloud,
         x,
         y,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs=sinkhorn_kwargs,
+        solve_kwargs=solve_kwargs,
         **geom_kwargs
     )
 
@@ -282,7 +282,7 @@ class TestSinkhornDivergence:
         indices_are_sorted=False,
         weights_x=a_copied,
         weights_y=b_copied,
-        sinkhorn_kwargs=sinkhorn_kwargs,
+        solve_kwargs=solve_kwargs,
         **geom_kwargs
     )
 
@@ -376,7 +376,7 @@ class TestSinkhornDivergence:
 
   # yapf: disable
   @pytest.mark.fast.with_args(
-      "sinkhorn_kwargs,epsilon", [
+      "solve_kwargs,epsilon", [
           ({"anderson": acceleration.AndersonAcceleration(memory=3)}, 1e-2),
           ({"anderson": acceleration.AndersonAcceleration(memory=6)}, None),
           ({"momentum": acceleration.Momentum(start=30)}, None),
@@ -386,16 +386,16 @@ class TestSinkhornDivergence:
   )
   # yapf: enable
   def test_euclidean_momentum_params(
-      self, sinkhorn_kwargs: Dict[str, Any], epsilon: Optional[float]
+      self, solve_kwargs: Dict[str, Any], epsilon: Optional[float]
   ):
-    # check if sinkhorn divergence sinkhorn_kwargs parameters used for
+    # check if sinkhorn divergence solve_kwargs parameters used for
     # momentum/Anderson are properly overridden for the symmetric (x,x) and
     # (y,y) parts.
     rngs = jax.random.split(self.rng, 2)
     threshold = 3.2e-3
     cloud_a = jax.random.uniform(rngs[0], (self._num_points[0], self._dim))
     cloud_b = jax.random.uniform(rngs[1], (self._num_points[1], self._dim))
-    sinkhorn_kwargs["threshold"] = threshold
+    solve_kwargs["threshold"] = threshold
 
     div, out = sinkhorn_divergence.sinkhorn_divergence(
         pointcloud.PointCloud,
@@ -404,7 +404,7 @@ class TestSinkhornDivergence:
         epsilon=epsilon,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs=sinkhorn_kwargs,
+        solve_kwargs=solve_kwargs,
     )
     assert div > 0.0
     assert threshold > out.errors[0][-1]
@@ -436,7 +436,7 @@ class TestSinkhornDivergenceGrad:
         epsilon=1.0,
         a=self._a,
         b=self._b,
-        sinkhorn_kwargs={"threshold": 0.05}
+        solve_kwargs={"threshold": 0.05}
     )
 
     delta = jax.random.normal(rngs[2], x.shape)


### PR DESCRIPTION
put `SinkhornDivergenceOutput` in the docs, rename `sinkhorn_kwargs` to `solve_kwargs` since those are parameters passed on to `linear.solve()` 