### PR TITLE
solve tests for soft-sort / unb. Bures + add xlim/ylim options in plot

### DIFF
--- a/src/ott/tools/plot.py
+++ b/src/ott/tools/plot.py
@@ -97,7 +97,9 @@ class Plot:
       cmap: str = "cool",
       scale_alpha_by_coupling: bool = False,
       alpha: float = 0.7,
-      title: Optional[str] = None
+      title: Optional[str] = None,
+      xlim: Optional[List[float]] = None,
+      ylim: Optional[List[float]] = None,
   ):
     if plt is None:
       raise RuntimeError("Please install `matplotlib` first.")
@@ -120,6 +122,8 @@ class Plot:
     self._scale_alpha_by_coupling = scale_alpha_by_coupling
     self._alpha = alpha
     self._title = title
+    self._xlim = xlim
+    self._ylim = ylim
 
   def _scatter(self, ot: Transport):
     """Compute the position and scales of the points on a 2D plot."""
@@ -195,6 +199,12 @@ class Plot:
           alpha=alpha
       )
       self._lines.append(line)
+
+    if self._xlim is not None:
+      self.ax.set_xlim(self._xlim)
+    if self._ylim is not None:
+      self.ax.set_ylim(self._ylim)
+
     return [self._points_x, self._points_y] + self._lines
 
   def update(self,

--- a/tests/solvers/linear/sinkhorn_misc_test.py
+++ b/tests/solvers/linear/sinkhorn_misc_test.py
@@ -100,13 +100,14 @@ class TestSinkhornBures:
     self.n = 11
     self.m = 13
     self.dim = 7
+    self.deg_freedom = self.dim + 4
     self.rngs = jax.random.split(jax.random.key(0), 6)
 
-    x = jax.random.normal(self.rngs[0], (self.n, self.dim, self.dim))
-    y = jax.random.normal(self.rngs[1], (self.m, self.dim, self.dim))
+    x = jax.random.normal(self.rngs[0], (self.n, self.dim, self.deg_freedom))
+    y = jax.random.normal(self.rngs[1], (self.m, self.dim, self.deg_freedom))
 
-    sig_x = jnp.matmul(x, jnp.transpose(x, (0, 2, 1))) / self.dim
-    sig_y = jnp.matmul(y, jnp.transpose(y, (0, 2, 1))) / self.dim
+    sig_x = jnp.matmul(x, jnp.transpose(x, (0, 2, 1))) / self.deg_freedom
+    sig_y = jnp.matmul(y, jnp.transpose(y, (0, 2, 1))) / self.deg_freedom
 
     m_x = jax.random.uniform(self.rngs[2], (self.n, self.dim))
     m_y = jax.random.uniform(self.rngs[3], (self.m, self.dim))
@@ -134,8 +135,6 @@ class TestSinkhornBures:
       ws_x = jnp.abs(jax.random.uniform(rng1, (self.x.shape[0], 1))) + 1e-1
       ws_y = jnp.abs(jax.random.uniform(rng2, (self.y.shape[0], 1))) + 1e-1
       ws_x = ws_x.at[0].set(0.0)
-      ws_x = jnp.ones_like(ws_x)
-      ws_y = jnp.ones_like(ws_y)
       x = jnp.concatenate([ws_x, self.x], axis=1)
       y = jnp.concatenate([ws_y, self.y], axis=1)
       cost_fn = costs.UnbalancedBures(dimension=self.dim, gamma=0.9, sigma=0.98)

--- a/tests/solvers/linear/sinkhorn_misc_test.py
+++ b/tests/solvers/linear/sinkhorn_misc_test.py
@@ -105,8 +105,8 @@ class TestSinkhornBures:
     x = jax.random.normal(self.rngs[0], (self.n, self.dim, self.dim))
     y = jax.random.normal(self.rngs[1], (self.m, self.dim, self.dim))
 
-    sig_x = jnp.matmul(x, jnp.transpose(x, (0, 2, 1)))
-    sig_y = jnp.matmul(y, jnp.transpose(y, (0, 2, 1)))
+    sig_x = jnp.matmul(x, jnp.transpose(x, (0, 2, 1))) / self.dim
+    sig_y = jnp.matmul(y, jnp.transpose(y, (0, 2, 1))) / self.dim
 
     m_x = jax.random.uniform(self.rngs[2], (self.n, self.dim))
     m_y = jax.random.uniform(self.rngs[3], (self.m, self.dim))

--- a/tests/tools/soft_sort_test.py
+++ b/tests/tools/soft_sort_test.py
@@ -152,7 +152,7 @@ class TestSoftSort:
       my_ranks = jax.jit(my_ranks, static_argnames="num_targets")
 
     ranks = my_ranks(x)
-    np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.4, rtol=0.1)
 
     # soft-Ranks computed against target that is not the same size will
     # inevitably be "softer", i.e. less likely to look integer.
@@ -162,7 +162,7 @@ class TestSoftSort:
     target_weights = jax.random.uniform(rng2, (num_targets,))
     target_weights /= jnp.sum(target_weights)
     ranks = my_ranks(x, target_weights=target_weights)
-    np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.6, rtol=0.1)
 
   @pytest.mark.fast.with_args("axis,jit", [(0, False), (1, True)], only_fast=0)
   def test_topk_mask(self, axis, rng: jax.Array, jit: bool):

--- a/tests/tools/soft_sort_test.py
+++ b/tests/tools/soft_sort_test.py
@@ -152,18 +152,18 @@ class TestSoftSort:
       my_ranks = jax.jit(my_ranks, static_argnames="num_targets")
 
     ranks = my_ranks(x)
-    np.testing.assert_allclose(ranks, expected_ranks, atol=0.3, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.3, rtol=0.1)
 
     # soft-Ranks computed against target that is not the same size will
     # inevitably be "softer". Therefore increasing tolerance. Notice these
     # ranks are integers on the scale of the size of x at axis.
     ranks = my_ranks(x, num_targets=num_targets)
-    np.testing.assert_allclose(ranks, expected_ranks, atol=0.5, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
 
     target_weights = jax.random.uniform(rng2, (num_targets,))
     target_weights /= jnp.sum(target_weights)
     ranks = my_ranks(x, target_weights=target_weights)
-    np.testing.assert_allclose(ranks, expected_ranks, atol=0.5, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
 
   @pytest.mark.fast.with_args("axis,jit", [(0, False), (1, True)], only_fast=0)
   def test_topk_mask(self, axis, rng: jax.Array, jit: bool):

--- a/tests/tools/soft_sort_test.py
+++ b/tests/tools/soft_sort_test.py
@@ -157,7 +157,7 @@ class TestSoftSort:
     # soft-Ranks computed against target that is not the same size will
     # inevitably be "softer", i.e. less likely to look integer.
     ranks = my_ranks(x, num_targets=num_targets)
-    np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.6, rtol=0.1)
 
     target_weights = jax.random.uniform(rng2, (num_targets,))
     target_weights /= jnp.sum(target_weights)

--- a/tests/tools/soft_sort_test.py
+++ b/tests/tools/soft_sort_test.py
@@ -152,11 +152,10 @@ class TestSoftSort:
       my_ranks = jax.jit(my_ranks, static_argnames="num_targets")
 
     ranks = my_ranks(x)
-    np.testing.assert_allclose(expected_ranks, ranks, atol=0.3, rtol=0.1)
+    np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
 
     # soft-Ranks computed against target that is not the same size will
-    # inevitably be "softer". Therefore increasing tolerance. Notice these
-    # ranks are integers on the scale of the size of x at axis.
+    # inevitably be "softer", i.e. less likely to look integer.
     ranks = my_ranks(x, num_targets=num_targets)
     np.testing.assert_allclose(expected_ranks, ranks, atol=0.5, rtol=0.1)
 
@@ -177,7 +176,7 @@ class TestSoftSort:
         soft_sort.topk_mask,
         squashing_fun=lambda x: x,
         epsilon=1e-4,  # needed to recover a sharp mask given close ties
-        max_iterations=15000,  # needed to recover a sharp mask given close ties
+        max_iterations=15_000,
         axis=axis
     )
     if jit:

--- a/tests/tools/soft_sort_test.py
+++ b/tests/tools/soft_sort_test.py
@@ -134,6 +134,8 @@ class TestSoftSort:
     num_targets = 13
     rng1, rng2 = jax.random.split(rng, 2)
     x = jax.random.uniform(rng1, (8, 5, 2))
+    #print('X')
+    #print(x.tolist())
     expected_ranks = jnp.argsort(
         jnp.argsort(x, axis=axis), axis=axis
     ).astype(float)
@@ -144,22 +146,24 @@ class TestSoftSort:
         squashing_fun=lambda x: x,
         epsilon=1e-4,
         axis=axis,
-        max_iterations=5000,
+        max_iterations=20_000,
     )
     if jit:
       my_ranks = jax.jit(my_ranks, static_argnames="num_targets")
 
     ranks = my_ranks(x)
-
     np.testing.assert_allclose(ranks, expected_ranks, atol=0.3, rtol=0.1)
 
+    # soft-Ranks computed against target that is not the same size will
+    # inevitably be "softer". Therefore increasing tolerance. Notice these
+    # ranks are integers on the scale of the size of x at axis.
     ranks = my_ranks(x, num_targets=num_targets)
-    np.testing.assert_allclose(ranks, expected_ranks, atol=0.3, rtol=0.1)
+    np.testing.assert_allclose(ranks, expected_ranks, atol=0.5, rtol=0.1)
 
     target_weights = jax.random.uniform(rng2, (num_targets,))
     target_weights /= jnp.sum(target_weights)
     ranks = my_ranks(x, target_weights=target_weights)
-    np.testing.assert_allclose(ranks, expected_ranks, atol=0.3, rtol=0.1)
+    np.testing.assert_allclose(ranks, expected_ranks, atol=0.5, rtol=0.1)
 
   @pytest.mark.fast.with_args("axis,jit", [(0, False), (1, True)], only_fast=0)
   def test_topk_mask(self, axis, rng: jax.Array, jit: bool):


### PR DESCRIPTION
minor fixes to solve some of the tests failing due to errors, notable `test_ranks` and `test_bures_point_cloud`

`test_ranks` fixed due to overzealous tolerance (soft ranks are reals in `[0,n-1]` for a vector of size `n`, that should look like corresponding integers, but cannot in general, due to regularization and in other scenarios where there is a number of targets that's different from `n`, be that close)

`test_bures_point_cloud` : the order of magnitude of covariance matrices was too large, with dets in the thousands, which resulted in numerical instability. 

also adds ability to set static `xlim` and `ylim` in plot tool to set a scale when using animations.