### PR TITLE
Adds `entropy` of coupling computations and instantiates `Dotp` to `LRCGeometry`

### DIFF
--- a/src/ott/geometry/costs.py
+++ b/src/ott/geometry/costs.py
@@ -390,6 +390,10 @@ class Dotp(CostFn):
   def twist_operator(self, vec, dual_vec, variable) -> jnp.ndarray:
     return -vec if variable else -dual_vec
 
+  def norm(self, x: jnp.ndarray) -> jnp.ndarray:
+    """Compute squared Euclidean norm for vector. Only used for rescaling."""
+    return jnp.sum(x ** 2, axis=-1)
+
 
 @jtu.register_pytree_node_class
 class RegTICost(TICost):

--- a/src/ott/problems/linear/linear_problem.py
+++ b/src/ott/problems/linear/linear_problem.py
@@ -93,6 +93,11 @@ class LinearProblem:
     return self.geom.shape[0] == self.geom.shape[1]
 
   @property
+  def is_assignment(self) -> bool:
+    """True if assignment problem."""
+    return self.is_equal_size and self.is_uniform and self.is_balanced
+
+  @property
   def epsilon(self) -> float:
     """Entropic regularization."""
     return self.geom.epsilon

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -507,7 +507,7 @@ class SinkhornOutput(NamedTuple):
 
   @property
   def entropy_exact(self) -> jnp.ndarray:
-    """Eaxct entropy of the coupling when the problem is balanced.
+    """Exact entropy of the coupling when the problem is balanced.
 
     Materializes transport matrix.
     """

--- a/src/ott/solvers/linear/sinkhorn.py
+++ b/src/ott/solvers/linear/sinkhorn.py
@@ -492,6 +492,34 @@ class SinkhornOutput(NamedTuple):
     """The second dual potential."""
     return self.potentials[1]
 
+  @property
+  def entropy_proxy(self) -> jnp.ndarray:
+    """Entropy of the coupling when the problem is balanced.
+
+    This proxy computation assumes convergence of the Sinkhorn algorithm (it
+    leverages the identity that the dual and primal formulations of EOT
+    coincide). As a result, it does not require materializing the transport
+    matrix, just applying it to the cost itself, which can be significantly
+    cheaper when the cost matrix admits a low-rank factorization.
+    """
+    assert self.ot_prob.is_balanced, "Entropy only valid for balanced problems."
+    return (self.primal_cost - self.ent_reg_cost) / self.geom.epsilon
+
+  @property
+  def entropy_exact(self) -> jnp.ndarray:
+    """Eaxct entropy of the coupling when the problem is balanced.
+
+    Materializes transport matrix.
+    """
+    return jnp.sum(jsp.special.entr(self.matrix))
+
+  @property
+  def normalized_entropy(self) -> jnp.ndarray:
+    """Renormalized entropy of coupling when the problem is assignment."""
+    is_assign = self.ot_prob.is_assignment
+    assert is_assign, "Normalized entropy only valid for assignment problem."
+    return self.entropy_proxy / jnp.log(self.geom.shape[0]) - 1.0
+
 
 @jax.tree_util.register_pytree_node_class
 class Sinkhorn:

--- a/tests/geometry/lr_cost_test.py
+++ b/tests/geometry/lr_cost_test.py
@@ -86,6 +86,7 @@ class TestLRGeometry:
 
     geom = pointcloud.PointCloud(x, y, cost_fn=costs.Dotp())
     geom_lr = geom.to_LRCGeometry()
+    assert isinstance(geom_lr, low_rank.LRCGeometry)
 
     for dim, axis in ((m, 1), (n, 0)):
       for mat_shape in ((dim, 2), (dim,)):

--- a/tests/geometry/lr_cost_test.py
+++ b/tests/geometry/lr_cost_test.py
@@ -44,25 +44,49 @@ class TestLRGeometry:
             rtol=1e-4
         )
 
-  @pytest.mark.parametrize(
-      "scale_cost", ["mean", "max_cost", "max_bound", 42.0]
-  )
+  @pytest.mark.parametrize("scale_cost", ["mean", "max_cost", "max_bound", 4.7])
   def test_conversion_pointcloud(
-      self, rng: jax.Array, scale_cost: Union[str, float]
+      self,
+      rng: jax.Array,
+      scale_cost: Union[str, float],
   ):
     """Test conversion from PointCloud to LRCGeometry."""
+    cost_fn = costs.SqEuclidean()
+
     n, m, d = 17, 11, 3
     rngs = jax.random.split(rng, 3)
-    x = jax.random.normal(rngs[0], (n, d))
+    x = jax.random.normal(rngs[0], (n, d)) + .1
     y = jax.random.normal(rngs[1], (m, d))
 
-    geom = pointcloud.PointCloud(x, y, scale_cost=scale_cost)
+    geom = pointcloud.PointCloud(x, y, cost_fn=cost_fn, scale_cost=scale_cost)
     geom_lr = geom.to_LRCGeometry()
 
     assert geom._scale_cost == geom_lr._scale_cost
     np.testing.assert_allclose(
         geom.inv_scale_cost, geom_lr.inv_scale_cost, rtol=1e-6, atol=1e-6
     )
+    for dim, axis in ((m, 1), (n, 0)):
+      for mat_shape in ((dim, 2), (dim,)):
+        mat = jax.random.normal(rngs[2], mat_shape)
+        np.testing.assert_allclose(
+            geom.apply_cost(mat, axis=axis),
+            geom_lr.apply_cost(mat, axis=axis),
+            rtol=1e-4
+        )
+
+  def test_conversion_pointcloud_dotp(
+      self,
+      rng: jax.Array,
+  ):
+    """Test conversion from PointCloud to LRCGeometry."""
+    n, m, d = 17, 11, 3
+    rngs = jax.random.split(rng, 3)
+    x = jax.random.normal(rngs[0], (n, d)) + .1
+    y = jax.random.normal(rngs[1], (m, d))
+
+    geom = pointcloud.PointCloud(x, y, cost_fn=costs.Dotp())
+    geom_lr = geom.to_LRCGeometry()
+
     for dim, axis in ((m, 1), (n, 0)):
       for mat_shape in ((dim, 2), (dim,)):
         mat = jax.random.normal(rngs[2], mat_shape)

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -602,7 +602,7 @@ class TestSinkhorn:
     cost = jnp.sum(out.matrix * out.geom.cost_matrix)
     np.testing.assert_allclose(cost, out.primal_cost, rtol=1e-5, atol=1e-5)
 
-  @pytest.mark.fast.with_args(cost_fn=[costs.SqEuclidean(), costs.Dotp()],)
+  @pytest.mark.fast.with_args(cost_fn=[costs.SqEuclidean(), costs.Dotp()])
   def test_entropy(self, cost_fn):
     """Test computation of entropy of solution."""
     geom = pointcloud.PointCloud(self.x, self.y, cost_fn=cost_fn, epsilon=1e-3)
@@ -618,7 +618,7 @@ class TestSinkhorn:
         ent_transport, out.entropy_exact, atol=1e-3, rtol=1e-3
     )
 
-  @pytest.mark.fast.with_args(cost_fn=[costs.SqEuclidean(), costs.Dotp()],)
+  @pytest.mark.fast.with_args(cost_fn=[costs.SqEuclidean(), costs.Dotp()])
   def test_norm_entropy(self, cost_fn):
     """Test computation of entropy of solution."""
     geom = pointcloud.PointCloud(self.x, self.x)

--- a/tests/solvers/linear/sinkhorn_test.py
+++ b/tests/solvers/linear/sinkhorn_test.py
@@ -22,6 +22,7 @@ import pytest
 import jax
 import jax.experimental.sparse as jesp
 import jax.numpy as jnp
+import jax.scipy as jsp
 import numpy as np
 import scipy as sp
 
@@ -600,6 +601,33 @@ class TestSinkhorn:
                                atol=1e-1)
     cost = jnp.sum(out.matrix * out.geom.cost_matrix)
     np.testing.assert_allclose(cost, out.primal_cost, rtol=1e-5, atol=1e-5)
+
+  @pytest.mark.fast.with_args(cost_fn=[costs.SqEuclidean(), costs.Dotp()],)
+  def test_entropy(self, cost_fn):
+    """Test computation of entropy of solution."""
+    geom = pointcloud.PointCloud(self.x, self.y, cost_fn=cost_fn, epsilon=1e-3)
+
+    lin_prob = linear_problem.LinearProblem(geom, a=self.a, b=self.b)
+    solver = sinkhorn.Sinkhorn(threshold=1e-4)
+    out = solver(lin_prob)
+    ent_transport = jnp.sum(jsp.special.entr(out.matrix))
+    np.testing.assert_allclose(
+        ent_transport, out.entropy_proxy, atol=1e-3, rtol=1e-3
+    )
+    np.testing.assert_allclose(
+        ent_transport, out.entropy_exact, atol=1e-3, rtol=1e-3
+    )
+
+  @pytest.mark.fast.with_args(cost_fn=[costs.SqEuclidean(), costs.Dotp()],)
+  def test_norm_entropy(self, cost_fn):
+    """Test computation of entropy of solution."""
+    geom = pointcloud.PointCloud(self.x, self.x)
+    out = linear.solve(geom)
+    ent_transport = jnp.sum(jsp.special.entr(out.matrix))
+    norm_ent = ent_transport / jnp.log(geom.shape[0]) - 1.0
+    np.testing.assert_allclose(
+        norm_ent, out.normalized_entropy, atol=1e-3, rtol=1e-3
+    )
 
   @pytest.mark.parametrize("lse_mode", [False, True])
   def test_f_potential_is_zero_centered(self, lse_mode: bool):


### PR DESCRIPTION
computing the entropy of a coupling solution can be done in two different ways:
- `entropy_proxy`: this computation is only valid when the Sinkhorn algorithm has converged to a reasonable tolerance, as it exploits primal/dual equality of objectives. Used by default.
- `entropy_exact` materializes the coupling and computes its entropy. This is a lot more compute heavy, but more reliable.

`proxy` is used by default.

also, `Dotp` can now be instantiated as `LRCGeometry` quite trivially.

also, introduction of `normalized_entropy` for couplings on assignment problems, leveraging the fact that entropy of a bistochastic assignemnt matrix is sandwiched between `log n` and `2 logn`