### PR TITLE
Fix: replace jnp.product with jnp.prod in grid tutorial

### DIFF
--- a/docs/tutorials/geometry/100_grid.ipynb
+++ b/docs/tutorials/geometry/100_grid.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "executionInfo": {
      "elapsed": 5339,
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "executionInfo": {
      "elapsed": 2768,
@@ -144,7 +144,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Regularized optimal transport cost = 0.08210793137550354\n"
+      "Regularized OT cost = 0.07269361615180969\n"
      ]
     }
    ],
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "executionInfo": {
      "elapsed": 2014,
@@ -191,7 +191,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Regularized optimal transport cost = 0.28149110078811646\n"
+      "Regularized optimal transport cost = 0.28033384680747986\n"
      ]
     }
    ],
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "executionInfo": {
      "elapsed": 279,
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "executionInfo": {
      "elapsed": 1810,
@@ -285,7 +285,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Regularized optimal transport cost = 1.2038968801498413\n"
+      "Regularized optimal transport cost = 1.2316354513168335\n"
      ]
     }
    ],
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {
     "executionInfo": {
      "elapsed": 6373,
@@ -350,20 +350,20 @@
     "a = a.ravel() / jnp.sum(a)\n",
     "b = b.ravel() / jnp.sum(b)\n",
     "\n",
-    "print(\"Total size of grid: \", jnp.product(jnp.array(grid_size)))"
+    "print(\"Total size of grid: \", jnp.prod(jnp.array(grid_size)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.03 s ± 17.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
-      "Regularized optimal transport cost using Grid = 0.10972004383802414\n",
+      "682 ms ± 12.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "Regularized optimal transport cost using Grid = 0.10546869784593582\n",
       "\n"
      ]
     }
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,18 +404,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6min 5s ± 5.8 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
-      "Regularized optimal transport cost using PointCloud = 0.10972030460834503\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%timeit solver(prob_pointcloud).reg_ot_cost.block_until_ready()\n",
     "out_pointcloud = solver(prob_pointcloud)\n",
@@ -436,7 +427,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "my-venv",
    "language": "python",
    "name": "python3"
   },
@@ -450,12 +441,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
-   }
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the tutorial 100_grid.ipynb, there's a code example using `jnp.product` which raises an AttributeError as this function doesn't exist in JAX's NumPy. The correct function to use is `jnp.prod`.