### PR TITLE
Modify `FenchelConjugateLBFGS` to handle data in higher dimensions

### DIFF
--- a/src/ott/neural/networks/layers/conjugate.py
+++ b/src/ott/neural/networks/layers/conjugate.py
@@ -94,10 +94,10 @@ class FenchelConjugateLBFGS(FenchelConjugateSolver):
       y: jnp.ndarray,
       x_init: Optional[jnp.array] = None
   ) -> ConjugateResults:
-    assert y.ndim == 1, y.ndim
+    assert y.ndim
 
     solver = LBFGS(
-        fun=lambda x: f(x) - x.dot(y),
+        fun=lambda x: f(x) - x.ravel().dot(y.ravel()),
         tol=self.gtol,
         maxiter=self.max_iter,
         linesearch=self.linesearch_type,


### PR DESCRIPTION
Right now, the conjugate solver in the neural dual solver can only handle data in one dimension.

A simple modification in `FenchelConjugateLBFGS` should allow us to extend the solver to higher dimensions. I have used the modified code with a neural Brenier potential on 2D images and there was no issue.