### PR TITLE
Fix/low rank conversion pointcloud

### DIFF
--- a/src/ott/geometry/pointcloud.py
+++ b/src/ott/geometry/pointcloud.py
@@ -278,19 +278,27 @@ class PointCloud(geometry.Geometry):
         the point cloud does not have squared Euclidean cost.
 
     Returns:
-      Returns the unmodified point cloud if :math:`n m \ge (n + m) d`, where
-      :math:`n, m` is the shape and :math:`d` is the dimension of the point
-      cloud with squared Euclidean cost.
-      Otherwise, returns the re-scaled low-rank geometry.
+      :class:`~ott.geometry.low_rank.LRCGeometry` or
+      :class:`~ott.geometry.pointcloud.PointCloud`:
+      The re-scaled low-rank geometry if:
+
+      1. :math:`n m > (n + m) d`, where
+         :math:`n, m` is the shape and :math:`d` is the
+         dimension of the point cloud with squared
+         Euclidean cost; or
+      2. ``rank=0`` is passed as keyword argument.
+
+      Otherwise, returns the unmodified point cloud.
     """
+    force = (kwargs.get("rank") == 0)
     if self.is_squared_euclidean:
-      if self._check_LRC_dim:
+      if force or self._check_LRC_dim:
         return self._sqeucl_to_lr(scale)
       # we don't update the `scale_factor` because in GW, the linear cost
       # is first materialized and then scaled by `fused_penalty` afterwards
       return self
     if self.is_neg_dotp:
-      if self._check_LRC_dim:
+      if force or self._check_LRC_dim:
         return self._dotp_to_lr(scale)
       return self
     return super().to_LRCGeometry(scale=scale, **kwargs)


### PR DESCRIPTION
This PR fixes the issue #669 . 

# root cause
Root cause seems to be that `PointCloud._check_LRC_dim` was False in this case, and so `PointCloud.to_LRCGeometry()` returned the unmodified point cloud; which meant that the `geom.to_LRCGeometry(rank=0, scale=scale, **kwargs)` call in grid.py was not returning a `low_rank.LRCGeometry` object, and so the line `c_1, c_2 = geom.cost_1, geom.cost_2` causes the crash because `AttributeError: 'PointCloud' object has no attribute 'cost_1'`.

# fix 
As the inline comments above `geom.to_LRCGeometry(rank=0, scale=scale, **kwargs)` call in grid.py explain, `rank=0` is supposed to force low rank conversion. But, `PointCloud.to_LRCGeometry()` was ignoring that kwarg. I added a Boolean flag called `force = (kwargs.get("rank") == 0)` to coerce a low rank conversion.

The repro code from the issue now runs:

```python
import jax.numpy as jnp
from ott.geometry.grid import Grid
from ott.problems.linear.linear_problem import LinearProblem
from ott.solvers.linear.sinkhorn import Sinkhorn
grid = Grid(grid_size=(2,))
prob = LinearProblem(grid, a=jnp.array([1,0]), b=jnp.array([0,1]))
out = Sinkhorn()(prob)
print(out.primal_cost)
```
```
1.0
```

