### PR TITLE
docs(tutorials): change ReST inline role to MyST

### DIFF
--- a/docs/tutorials/linear/200_sinkhorn_divergence_gradient_flow.ipynb
+++ b/docs/tutorials/linear/200_sinkhorn_divergence_gradient_flow.ipynb
@@ -19419,7 +19419,7 @@
    "source": [
     "## Gradient flow with $\\mathrm{S}_\\varepsilon$\n",
     "\n",
-    "By slightly adapting the previous function, we can compute the gradient flow of the :term:`Sinkhorn divergence` using the {func}`~ott.tools.sinkhorn_divergence.sinkdiv` method designed to compare two point clouds, instead of the regularized OT cost."
+    "By slightly adapting the previous function, we can compute the gradient flow of the {term}`Sinkhorn divergence` using the {func}`~ott.tools.sinkhorn_divergence.sinkdiv` method designed to compare two point clouds, instead of the regularized OT cost."
    ]
   },
   {

--- a/docs/tutorials/neural/200_Monge_Gap.ipynb
+++ b/docs/tutorials/neural/200_Monge_Gap.ipynb
@@ -324,7 +324,7 @@
     "$$\n",
     "\\min_{T:\\mathbb{R}^d \\rightarrow \\mathbb{R}^d} \\Delta(T\\sharp \\mu, \\nu) + \\lambda_\\mathrm{MG} \\mathcal{M}_\\mu^c(T)\n",
     "$$\n",
-    "For all fittings, we use $\\Delta = S_{\\varepsilon, \\ell_2^2}$, the :term:`Sinkhorn divergence`, {func}`~ott.tools.sinkhorn_divergence.sinkdiv` with the {class}`squared Euclidean cost <ott.geometry.costs.SqEuclidean>` :term:`ground cost` function `cost_fn` (corresponding to $c$), as well as the `epsilon` regularization parameters to compute approximated Wasserstein distances, both for fitting and regularizer."
+    "For all fittings, we use $\\Delta = S_{\\varepsilon, \\ell_2^2}$, the {term}`Sinkhorn divergence`, {func}`~ott.tools.sinkhorn_divergence.sinkdiv` with the {class}`squared Euclidean cost <ott.geometry.costs.SqEuclidean>` {term}`ground cost` function `cost_fn` (corresponding to $c$), as well as the `epsilon` regularization parameters to compute approximated Wasserstein distances, both for fitting and regularizer."
    ]
   },
   {


### PR DESCRIPTION
# Issue
- Some tutorial notebooks used ReST inline role syntax for glossary terms `:term:` instead of MyST `{term}`, breaking the hyperlinks, see for instance [Point Cloud](https://ott-jax.readthedocs.io/tutorials/geometry/000_point_cloud.html).
- Missing asterisk for tuple unpacking causes an error for $W_{\text{cosine}}$ Gradient Flow in the  [Point Cloud tutorial](https://ott-jax.readthedocs.io/tutorials/geometry/000_point_cloud.html#ot-gradient-flows).

# Fix
- Instances of `:term:` in notebooks replaced with `{term}`; now correctly link to the terms in glossary.
- Fixed the tuple unpacking error for Point Cloud tutorial. This required rerunning the notebook, hence the large diff. 