### PR TITLE
Migrate ICNN and layers to Flax NNX, add KeyNet

### DIFF
--- a/src/ott/neural/methods/neuraldual.py
+++ b/src/ott/neural/methods/neuraldual.py
@@ -27,6 +27,7 @@ import jax
 import jax.numpy as jnp
 
 import optax
+from flax import nnx
 
 from ott import utils
 from ott.geometry import costs
@@ -144,16 +145,26 @@ class W2NeuralDual:
       optimizer_g = optax.adam(learning_rate=0.0001, b1=0.5, b2=0.9, eps=1e-8)
 
     # set default neural architectures
+    rng = utils.default_prng_key(rng)
+    rng, rng_init_f, rng_init_g = jax.random.split(rng, 3)
     if neural_f is None:
-      neural_f = icnn.ICNN(dim_data=dim_data, dim_hidden=[64, 64, 64, 64])
+      neural_f = icnn.ICNN(
+          input_dim=dim_data,
+          dim_hidden=[64, 64, 64, 64],
+          rngs=nnx.Rngs(rng_init_f),
+      )
     if neural_g is None:
-      neural_g = icnn.ICNN(dim_data=dim_data, dim_hidden=[64, 64, 64, 64])
+      neural_g = icnn.ICNN(
+          input_dim=dim_data,
+          dim_hidden=[64, 64, 64, 64],
+          rngs=nnx.Rngs(rng_init_g),
+      )
     self.neural_f = neural_f
     self.neural_g = neural_g
 
     # set optimizer and networks
     self.setup(
-        utils.default_prng_key(rng),
+        rng,
         neural_f,
         neural_g,
         dim_data,

--- a/src/ott/neural/networks/icnn.py
+++ b/src/ott/neural/networks/icnn.py
@@ -96,7 +96,7 @@ class ICNN(nnx.Module):
       self,
       dim_hidden: Sequence[int],
       *,
-      dim_data: Optional[int] = None,
+      input_dim: int,
       output_dim: int = 1,
       rectifier_fn: Callable[[jax.Array], jax.Array] = jax.nn.softplus,
       act_fn: Callable[[jax.Array], jax.Array] = jax.nn.relu,
@@ -110,48 +110,29 @@ class ICNN(nnx.Module):
       bias_init: nnx.initializers.Initializer = DEFAULT_BIAS_INIT,
       rngs: nnx.Rngs,
   ):
-    self._dim_hidden = list(dim_hidden) + [output_dim]
     self._output_dim = output_dim
     self._act_fn_call = act_fn
-    self._dim_data = dim_data
-    self._rngs = rngs
-    self._rectifier_fn = rectifier_fn
-    self._wx_inject = wx_inject
-    self._use_bias = use_bias
-    self._use_softmax = use_softmax
-    self._use_sinkhorn = use_sinkhorn
-    self._kernel_init = kernel_init
-    self._wz_kernel_init = wz_kernel_init
-    self._bias_init = bias_init
-    self._pos_def_rank = pos_def_rank
-    self._initialized = False
 
-    # Initialize immediately if dim_data is provided
-    if dim_data is not None:
-      self._do_init(dim_data)
-
-  def _do_init(self, dim_data: int) -> None:
-    """Initialize layers."""
-    dims = [dim_data] + self._dim_hidden
+    dim_hidden = list(dim_hidden) + [output_dim]
+    dims = [input_dim] + dim_hidden
     num_layers = len(dims) - 2
-    inject_mask = _normalize_wx_inject(self._wx_inject, num_layers)
-    rngs = self._rngs
+    inject_mask = _normalize_wx_inject(wx_inject, num_layers)
 
     self.wx0 = nnx.Linear(
-        dim_data,
+        input_dim,
         dims[1],
-        use_bias=self._use_bias,
-        kernel_init=self._kernel_init,
-        bias_init=self._bias_init,
+        use_bias=use_bias,
+        kernel_init=kernel_init,
+        bias_init=bias_init,
         rngs=rngs,
     )
 
     self.wx_layers = nnx.List([
         nnx.Linear(
-            dim_data,
+            input_dim,
             d_out,
             use_bias=False,
-            kernel_init=self._kernel_init,
+            kernel_init=kernel_init,
             rngs=rngs,
         ) if inject else None for d_out, inject in zip(dims[2:], inject_mask)
     ])
@@ -160,34 +141,32 @@ class ICNN(nnx.Module):
         posdef.PositiveDense(
             d_in,
             d_out,
-            rectifier_fn=self._rectifier_fn,
-            use_softmax=self._use_softmax,
-            use_sinkhorn=self._use_sinkhorn,
-            use_bias=self._use_bias,
-            kernel_init=self._wz_kernel_init,
-            bias_init=self._bias_init,
+            rectifier_fn=rectifier_fn,
+            use_softmax=use_softmax,
+            use_sinkhorn=use_sinkhorn,
+            use_bias=use_bias,
+            kernel_init=wz_kernel_init,
+            bias_init=bias_init,
             rngs=rngs,
         ) for d_in, d_out in zip(dims[1:-1], dims[2:])
     ])
 
     self.pos_def_potentials = (
         posdef.PosDefPotentials(
-            dim_data,
-            self._output_dim,
-            rank=self._pos_def_rank,
+            input_dim,
+            output_dim,
+            rank=pos_def_rank,
             use_linear=True,
             use_bias=True,
             rngs=rngs,
-        ) if self._pos_def_rank > 0 else None
+        ) if pos_def_rank > 0 else None
     )
-    self._dim_data = dim_data
-    self._initialized = True
 
   def __call__(self, x: jax.Array) -> jax.Array:
     """Evaluate the ICNN.
 
     Args:
-      x: Input of shape ``[..., dim_data]``.
+      x: Input of shape ``[..., input_dim]``.
 
     Returns:
       Output of shape ``[...]`` if ``output_dim == 1``, else
@@ -196,9 +175,6 @@ class ICNN(nnx.Module):
     squeeze = x.ndim == 1
     if squeeze:
       x = x[None]
-
-    if not self._initialized:
-      self._do_init(x.shape[-1])
 
     z = self._act_fn_call(self.wx0(x))
 
@@ -237,7 +213,7 @@ class KeyNet(nnx.Module):
 
   Args:
     dim_hidden: Sequence of hidden layer sizes.
-    output_dim: Output vector dimension. Typically equals the input
+    output_dim: Output vector dimension. Typically, equals the input
       dimension for gradient-of-potential interpretation.
     resnet: If True, output ``x + F(x)`` instead of ``F(x)``.
     act_fn: Activation function.
@@ -254,7 +230,7 @@ class KeyNet(nnx.Module):
       self,
       dim_hidden: Sequence[int],
       *,
-      dim_data: Optional[int] = None,
+      input_dim: int,
       output_dim: Optional[int] = None,
       resnet: bool = False,
       act_fn: Callable[[jax.Array], jax.Array] = jax.nn.relu,
@@ -265,87 +241,63 @@ class KeyNet(nnx.Module):
       final_layer_scale: Optional[float] = None,
       rngs: nnx.Rngs,
   ):
-    self._dim_hidden = list(dim_hidden)
-    self._output_dim = output_dim
     self._resnet = resnet
-    self._act_fn = act_fn
-    self._wx_inject = wx_inject
-    self._use_bias = use_bias
-    self._kernel_init = kernel_init
-    self._bias_init = bias_init
-    self._final_layer_scale = final_layer_scale
-    self._initialized = False
-    self._rngs = rngs
+    self._act_fn_call = act_fn
 
-    if dim_data is not None:
-      self._do_init(dim_data)
-
-  def _do_init(self, dim_data: int) -> None:
-    """Initialize layers on first call."""
-    output_dim = self._output_dim if self._output_dim is not None else dim_data
-    dims = [dim_data] + self._dim_hidden + [output_dim]
+    output_dim = output_dim if output_dim is not None else input_dim
+    dims = [input_dim] + list(dim_hidden) + [output_dim]
     num_layers = len(dims) - 2
-    inject_mask = _normalize_wx_inject(self._wx_inject, num_layers)
-    rngs = self._rngs
+    inject_mask = _normalize_wx_inject(wx_inject, num_layers)
 
-    scale = self._final_layer_scale
+    scale = final_layer_scale
     if scale is None:
-      scale = 0.01 if self._resnet else 1.0
+      scale = 0.01 if resnet else 1.0
 
     def scaled_init(s):
-      base = self._kernel_init
 
       def init_fn(key, shape, dtype=None):
-        return s * base(key, shape, dtype)
+        return s * kernel_init(key, shape, dtype)
 
       return init_fn
 
-    # wx0
     self.wx0 = nnx.Linear(
-        dim_data,
+        input_dim,
         dims[1],
-        use_bias=self._use_bias,
-        kernel_init=self._kernel_init,
-        bias_init=self._bias_init,
+        use_bias=use_bias,
+        kernel_init=kernel_init,
+        bias_init=bias_init,
         rngs=rngs,
     )
 
-    # wx skip connections
     self.wx_layers = nnx.List([
         nnx.Linear(
-            dim_data,
+            input_dim,
             d_out,
             use_bias=False,
             kernel_init=scaled_init(scale) if
-            (i == num_layers - 1) else self._kernel_init,
+            (i == num_layers - 1) else kernel_init,
             rngs=rngs
         ) if inject else None
         for i, (d_out, inject) in enumerate(zip(dims[2:], inject_mask))
     ])
 
-    # wz layer-to-layer (NO positive constraint)
     self.wz_layers = nnx.List([
         nnx.Linear(
             d_in,
             d_out,
-            use_bias=self._use_bias,
+            use_bias=use_bias,
             kernel_init=scaled_init(scale) if
-            (i == len(dims) - 3) else self._kernel_init,
-            bias_init=self._bias_init,
+            (i == len(dims) - 3) else kernel_init,
+            bias_init=bias_init,
             rngs=rngs,
         ) for i, (d_in, d_out) in enumerate(zip(dims[1:-1], dims[2:]))
     ])
-
-    self._output_dim_actual = output_dim
-    self._dim_data = dim_data
-    self._act_fn_call = self._act_fn
-    self._initialized = True
 
   def __call__(self, x: jax.Array) -> jax.Array:
     """Compute scalar potential f(x) = <grad(x), x>.
 
     Args:
-      x: Input of shape ``[..., dim_data]``.
+      x: Input of shape ``[..., input_dim]``.
 
     Returns:
       Scalar output of shape ``[...]``.
@@ -357,7 +309,7 @@ class KeyNet(nnx.Module):
     """Compute the vector output (predicted gradient / key).
 
     Args:
-      x: Input of shape ``[..., dim_data]``.
+      x: Input of shape ``[..., input_dim]``.
 
     Returns:
       Output of shape ``[..., output_dim]``.
@@ -365,9 +317,6 @@ class KeyNet(nnx.Module):
     squeeze = x.ndim == 1
     if squeeze:
       x = x[None]
-
-    if not self._initialized:
-      self._do_init(x.shape[-1])
 
     z = self._act_fn_call(self.wx0(x))
 

--- a/src/ott/neural/networks/icnn.py
+++ b/src/ott/neural/networks/icnn.py
@@ -11,153 +11,378 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Optional, Sequence, Tuple, Union
+"""Input convex neural networks and KeyNet (vector-output variant)."""
+
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 
-from flax import linen as nn
+from flax import nnx
 
-from ott.neural.networks import potentials
 from ott.neural.networks.layers import posdef
 
-__all__ = ["ICNN"]
+__all__ = ["ICNN", "KeyNet"]
 
-DEFAULT_KERNEL_INIT = posdef.DEFAULT_KERNEL_INIT
-DEFAULT_RECTIFIER = nn.activation.relu
-DEFAULT_ACTIVATION = nn.activation.relu
+DEFAULT_KERNEL_INIT = nnx.initializers.lecun_normal()
+DEFAULT_BIAS_INIT = nnx.initializers.zeros_init()
 
 
-class ICNN(potentials.BasePotential):
+def _normalize_wx_inject(
+    wx_inject: Union[bool, Tuple[bool, ...], int],
+    num_layers: int,
+) -> Tuple[bool, ...]:
+  """Convert wx_inject specification to a boolean tuple.
+
+  Args:
+    wx_inject: Controls input re-injection pattern. Can be:
+      - ``bool``: inject at all layers (True) or none (False).
+      - ``tuple[bool, ...]``: explicit per-layer mask.
+      - ``int``: frequency (e.g., 3 means inject every 3rd layer).
+    num_layers: Number of layers after the first (len(dims) - 2).
+
+  Returns:
+    Tuple of booleans for each layer after wx0.
+  """
+  if isinstance(wx_inject, bool):
+    return (wx_inject,) * num_layers
+  if isinstance(wx_inject, int):
+    return tuple((i + 1) % wx_inject == 0 for i in range(num_layers))
+  assert len(wx_inject) == num_layers, (len(wx_inject), num_layers)
+  return tuple(wx_inject)
+
+
+class ICNN(nnx.Module):
   """Input convex neural network (ICNN).
 
   Implementation of input convex neural networks as introduced in
-  :cite:`amos:17` with initialization schemes proposed by :cite:`bunne:22`,
-  and (low-rank + diagonal) quadratic on inputs at each layer, by
+  :cite:`amos:17` with flexible input re-injection, multiple rectifier
+  options, and optional positive-definite quadratic potentials
   :cite:`vesseron:24`.
 
+  The network computes a convex function f: R^d -> R^k where convexity
+  holds component-wise when k > 1.
+
+  Architecture::
+
+    z_0 = act(W_x0 @ x)
+    z_i = act(W_z_i @ z_{i-1} + W_x_i @ x)   [wx_inject controls W_x_i]
+    out = z_N + pos_def_potentials(x)          [optional]
+
+  Convexity is enforced by requiring W_z_i >= 0 (via rectifier) and
+  using convex activation functions.
+
   Args:
-    dim_data: data dimensionality.
-    dim_hidden: sequence specifying size of hidden dimensions. The
-      output dimension of the last layer is 1 by default.
-    ranks: ranks of the matrices :math:`A_i` used as low-rank factors
-      for the quadratic potentials. If a sequence is passed, it must contain
-      ``len(dim_hidden) + 2`` elements, where the last 2 elements correspond
-      to the ranks of the final layer with dimension 1 and the potentials,
-      respectively.
-    init_fn: Initializer for the kernel weight matrices.
-      The default is :func:`~flax.linen.initializers.normal`.
-    act_fn: choice of activation function used in network architecture,
-      needs to be convex. The default is :func:`~flax.linen.activation.relu`.
-    pos_weights: Enforce positive weights with a projection.
-      If :obj:`False`, the positive weights should be enforced with clipping
-      or regularization in the loss.
-    rectifier_fn: function to ensure the non negativity of the weights.
-      The default is :func:`~flax.linen.activation.relu`.
-    gaussian_map_samples: Tuple of source and target points, used to initialize
-      the ICNN to mimic the linear Bures map that morphs the (Gaussian
-      approximation) of the input measure to that of the target measure. If
-      :obj:`None`, the identity initialization is used, and ICNN mimics half the
-      squared Euclidean norm.
+    dim_hidden: Sequence of hidden layer sizes. The output dimension
+      defaults to 1 (scalar potential); set ``output_dim`` for vector output.
+    output_dim: Output dimension. Defaults to 1 (scalar convex function).
+      When > 1, each output component is convex in the input.
+    rectifier_fn: Function applied to W_z kernels to enforce
+      non-negativity. The default is :func:`jax.nn.softplus`.
+    act_fn: Activation function (must be convex for the network to be
+      convex). The default is :func:`jax.nn.relu`.
+    wx_inject: Controls input re-injection at intermediate layers.
+      See :func:`_normalize_wx_inject`.
+    use_bias: Whether to use bias terms.
+    pos_def_rank: Rank of optional PosDefPotentials term. Set to 0
+      to disable (default).
+    kernel_init: Initializer for W_x (unrestricted) weights.
+    wz_kernel_init: Initializer for W_z (positive) weights.
+    bias_init: Initializer for biases.
+    rngs: Random number generators.
   """
 
-  dim_data: int
-  dim_hidden: Sequence[int]
-  ranks: Union[int, Tuple[int, ...]] = 1
-  init_fn: Callable[[jax.Array, Tuple[int, ...], Any],
-                    jnp.ndarray] = DEFAULT_KERNEL_INIT
-  act_fn: Callable[[jnp.ndarray], jnp.ndarray] = DEFAULT_ACTIVATION
-  pos_weights: bool = False
-  rectifier_fn: Callable[[jnp.ndarray], jnp.ndarray] = DEFAULT_RECTIFIER
-  gaussian_map_samples: Optional[Tuple[jnp.ndarray, jnp.ndarray]] = None
+  def __init__(
+      self,
+      dim_hidden: Sequence[int],
+      *,
+      dim_data: Optional[int] = None,
+      output_dim: int = 1,
+      rectifier_fn: Callable[[jax.Array], jax.Array] = jax.nn.softplus,
+      act_fn: Callable[[jax.Array], jax.Array] = jax.nn.relu,
+      wx_inject: Union[bool, Tuple[bool, ...], int] = True,
+      use_bias: bool = True,
+      use_softmax: bool = False,
+      use_sinkhorn: bool = False,
+      pos_def_rank: int = 0,
+      kernel_init: nnx.initializers.Initializer = DEFAULT_KERNEL_INIT,
+      wz_kernel_init: nnx.initializers.Initializer = DEFAULT_KERNEL_INIT,
+      bias_init: nnx.initializers.Initializer = DEFAULT_BIAS_INIT,
+      rngs: nnx.Rngs,
+  ):
+    self._dim_hidden = list(dim_hidden) + [output_dim]
+    self._output_dim = output_dim
+    self._act_fn_call = act_fn
+    self._dim_data = dim_data
+    self._rngs = rngs
+    self._rectifier_fn = rectifier_fn
+    self._wx_inject = wx_inject
+    self._use_bias = use_bias
+    self._use_softmax = use_softmax
+    self._use_sinkhorn = use_sinkhorn
+    self._kernel_init = kernel_init
+    self._wz_kernel_init = wz_kernel_init
+    self._bias_init = bias_init
+    self._pos_def_rank = pos_def_rank
+    self._initialized = False
 
-  def setup(self) -> None:  # noqa: D102
-    dim_hidden = list(self.dim_hidden) + [1]
-    *ranks, pos_def_rank = self._normalize_ranks()
+    # Initialize immediately if dim_data is provided
+    if dim_data is not None:
+      self._do_init(dim_data)
 
-    # final layer computes average, still with normalized rescaling
-    self.w_zs = [self._get_wz(dim) for dim in dim_hidden[1:]]
-    # subsequent layers re-injected into convex functions
-    self.w_xs = [
-        self._get_wx(dim, rank) for dim, rank in zip(dim_hidden, ranks)
-    ]
-    self.pos_def_potentials = self._get_pos_def_potentials(pos_def_rank)
+  def _do_init(self, dim_data: int) -> None:
+    """Initialize layers."""
+    dims = [dim_data] + self._dim_hidden
+    num_layers = len(dims) - 2
+    inject_mask = _normalize_wx_inject(self._wx_inject, num_layers)
+    rngs = self._rngs
 
-  @nn.compact
-  def __call__(self, x: jnp.ndarray) -> float:  # noqa: D102
-    w_x, *w_xs = self.w_xs
-    assert len(self.w_zs) == len(w_xs), (len(self.w_zs), len(w_xs))
-
-    z = self.act_fn(w_x(x))
-    for w_z, w_x in zip(self.w_zs, w_xs):
-      z = self.act_fn(w_z(z) + w_x(x))
-    z = z + self.pos_def_potentials(x)
-
-    return z.squeeze()
-
-  def _get_wz(self, dim: int) -> nn.Module:
-    if self.pos_weights:
-      return posdef.PositiveDense(
-          dim,
-          kernel_init=self.init_fn,
-          use_bias=False,
-          rectifier_fn=self.rectifier_fn,
-      )
-
-    return nn.Dense(
-        dim,
-        kernel_init=self.init_fn,
-        use_bias=False,
+    self.wx0 = nnx.Linear(
+        dim_data,
+        dims[1],
+        use_bias=self._use_bias,
+        kernel_init=self._kernel_init,
+        bias_init=self._bias_init,
+        rngs=rngs,
     )
 
-  def _get_wx(self, dim: int, rank: int) -> nn.Module:
-    return posdef.PosDefPotentials(
-        rank=rank,
-        num_potentials=dim,
-        use_linear=True,
-        use_bias=True,
-        kernel_diag_init=nn.initializers.constant(-2.0),
-        rectifier_fn=jax.nn.softplus,
-        kernel_lr_init=self.init_fn,
-        kernel_linear_init=self.init_fn,
-        bias_init=nn.initializers.zeros,
+    self.wx_layers = nnx.List([
+        nnx.Linear(
+            dim_data,
+            d_out,
+            use_bias=False,
+            kernel_init=self._kernel_init,
+            rngs=rngs,
+        ) if inject else None for d_out, inject in zip(dims[2:], inject_mask)
+    ])
+
+    self.wz_layers = nnx.List([
+        posdef.PositiveDense(
+            d_in,
+            d_out,
+            rectifier_fn=self._rectifier_fn,
+            use_softmax=self._use_softmax,
+            use_sinkhorn=self._use_sinkhorn,
+            use_bias=self._use_bias,
+            kernel_init=self._wz_kernel_init,
+            bias_init=self._bias_init,
+            rngs=rngs,
+        ) for d_in, d_out in zip(dims[1:-1], dims[2:])
+    ])
+
+    self.pos_def_potentials = (
+        posdef.PosDefPotentials(
+            dim_data,
+            self._output_dim,
+            rank=self._pos_def_rank,
+            use_linear=True,
+            use_bias=True,
+            rngs=rngs,
+        ) if self._pos_def_rank > 0 else None
     )
+    self._dim_data = dim_data
+    self._initialized = True
 
-  def _get_pos_def_potentials(self, rank: int) -> posdef.PosDefPotentials:
-    kwargs = {
-        "num_potentials": 1,
-        "use_linear": True,
-        "use_bias": True,
-        "bias_init": nn.initializers.zeros
-    }
+  def __call__(self, x: jax.Array) -> jax.Array:
+    """Evaluate the ICNN.
 
-    if self.gaussian_map_samples is None:
-      return posdef.PosDefPotentials(
-          rank=rank,
-          kernel_diag_init=nn.initializers.ones,
-          kernel_lr_init=nn.initializers.zeros,
-          kernel_linear_init=nn.initializers.zeros,
-          **kwargs,
-      )
+    Args:
+      x: Input of shape ``[..., dim_data]``.
 
-    source, target = self.gaussian_map_samples
-    return posdef.PosDefPotentials.init_from_samples(
-        source,
-        target,
-        rank=self.dim_data,
-        kernel_diag_init=nn.initializers.zeros,
-        **kwargs,
-    )
+    Returns:
+      Output of shape ``[...]`` if ``output_dim == 1``, else
+      ``[..., output_dim]``.
+    """
+    squeeze = x.ndim == 1
+    if squeeze:
+      x = x[None]
 
-  def _normalize_ranks(self) -> Tuple[int, ...]:
-    # +2 for the newly added layer with 1 + the final potentials
-    n_ranks = len(self.dim_hidden) + 2
-    if isinstance(self.ranks, int):
-      return (self.ranks,) * n_ranks
+    if not self._initialized:
+      self._do_init(x.shape[-1])
 
-    assert len(self.ranks) == n_ranks, (len(self.ranks), n_ranks)
-    return tuple(self.ranks)
+    z = self._act_fn_call(self.wx0(x))
+
+    for wx, wz in zip(self.wx_layers, self.wz_layers):
+      if wx is not None:
+        z = self._act_fn_call(wz(z) + wx(x))
+      else:
+        z = self._act_fn_call(wz(z))
+
+    if self.pos_def_potentials is not None:
+      z = z + self.pos_def_potentials(x)
+
+    if self._output_dim == 1:
+      z = z.squeeze(-1)
+
+    return z.squeeze(0) if squeeze else z
 
   @property
-  def is_potential(self) -> bool:  # noqa: D102
+  def is_potential(self) -> bool:
+    """Whether this module represents a potential (True) or vector field."""
+    return True
+
+
+class KeyNet(nnx.Module):
+  """Vector-output network with ICNN-like architecture.
+
+  Unlike :class:`ICNN` which outputs a scalar convex function and requires
+  autodiff to compute gradients, KeyNet directly outputs vectors. The
+  architecture mirrors ICNN but without non-negativity constraints on the
+  layer-to-layer weights.
+
+  The scalar potential is recovered as f(x) = <KeyNet(x), x>.
+
+  When ``resnet=True``, output is ``x + F(x)`` (residual mode), making
+  the model learn a correction to the input query.
+
+  Args:
+    dim_hidden: Sequence of hidden layer sizes.
+    output_dim: Output vector dimension. Typically equals the input
+      dimension for gradient-of-potential interpretation.
+    resnet: If True, output ``x + F(x)`` instead of ``F(x)``.
+    act_fn: Activation function.
+    wx_inject: Controls input re-injection pattern.
+    use_bias: Whether to use bias terms.
+    kernel_init: Initializer for all weights.
+    bias_init: Initializer for biases.
+    final_layer_scale: Scale for final layer init. Defaults to 0.01
+      for resnet mode (small initial corrections), 1.0 otherwise.
+    rngs: Random number generators.
+  """
+
+  def __init__(
+      self,
+      dim_hidden: Sequence[int],
+      *,
+      dim_data: Optional[int] = None,
+      output_dim: Optional[int] = None,
+      resnet: bool = False,
+      act_fn: Callable[[jax.Array], jax.Array] = jax.nn.relu,
+      wx_inject: Union[bool, Tuple[bool, ...], int] = True,
+      use_bias: bool = True,
+      kernel_init: nnx.initializers.Initializer = DEFAULT_KERNEL_INIT,
+      bias_init: nnx.initializers.Initializer = DEFAULT_BIAS_INIT,
+      final_layer_scale: Optional[float] = None,
+      rngs: nnx.Rngs,
+  ):
+    self._dim_hidden = list(dim_hidden)
+    self._output_dim = output_dim
+    self._resnet = resnet
+    self._act_fn = act_fn
+    self._wx_inject = wx_inject
+    self._use_bias = use_bias
+    self._kernel_init = kernel_init
+    self._bias_init = bias_init
+    self._final_layer_scale = final_layer_scale
+    self._initialized = False
+    self._rngs = rngs
+
+    if dim_data is not None:
+      self._do_init(dim_data)
+
+  def _do_init(self, dim_data: int) -> None:
+    """Initialize layers on first call."""
+    output_dim = self._output_dim if self._output_dim is not None else dim_data
+    dims = [dim_data] + self._dim_hidden + [output_dim]
+    num_layers = len(dims) - 2
+    inject_mask = _normalize_wx_inject(self._wx_inject, num_layers)
+    rngs = self._rngs
+
+    scale = self._final_layer_scale
+    if scale is None:
+      scale = 0.01 if self._resnet else 1.0
+
+    def scaled_init(s):
+      base = self._kernel_init
+
+      def init_fn(key, shape, dtype=None):
+        return s * base(key, shape, dtype)
+
+      return init_fn
+
+    # wx0
+    self.wx0 = nnx.Linear(
+        dim_data,
+        dims[1],
+        use_bias=self._use_bias,
+        kernel_init=self._kernel_init,
+        bias_init=self._bias_init,
+        rngs=rngs,
+    )
+
+    # wx skip connections
+    self.wx_layers = nnx.List([
+        nnx.Linear(
+            dim_data,
+            d_out,
+            use_bias=False,
+            kernel_init=scaled_init(scale) if
+            (i == num_layers - 1) else self._kernel_init,
+            rngs=rngs
+        ) if inject else None
+        for i, (d_out, inject) in enumerate(zip(dims[2:], inject_mask))
+    ])
+
+    # wz layer-to-layer (NO positive constraint)
+    self.wz_layers = nnx.List([
+        nnx.Linear(
+            d_in,
+            d_out,
+            use_bias=self._use_bias,
+            kernel_init=scaled_init(scale) if
+            (i == len(dims) - 3) else self._kernel_init,
+            bias_init=self._bias_init,
+            rngs=rngs,
+        ) for i, (d_in, d_out) in enumerate(zip(dims[1:-1], dims[2:]))
+    ])
+
+    self._output_dim_actual = output_dim
+    self._dim_data = dim_data
+    self._act_fn_call = self._act_fn
+    self._initialized = True
+
+  def __call__(self, x: jax.Array) -> jax.Array:
+    """Compute scalar potential f(x) = <grad(x), x>.
+
+    Args:
+      x: Input of shape ``[..., dim_data]``.
+
+    Returns:
+      Scalar output of shape ``[...]``.
+    """
+    g = self.gradient(x)
+    return jnp.sum(g * x, axis=-1)
+
+  def gradient(self, x: jax.Array) -> jax.Array:
+    """Compute the vector output (predicted gradient / key).
+
+    Args:
+      x: Input of shape ``[..., dim_data]``.
+
+    Returns:
+      Output of shape ``[..., output_dim]``.
+    """
+    squeeze = x.ndim == 1
+    if squeeze:
+      x = x[None]
+
+    if not self._initialized:
+      self._do_init(x.shape[-1])
+
+    z = self._act_fn_call(self.wx0(x))
+
+    for wx, wz in zip(self.wx_layers, self.wz_layers):
+      if wx is not None:
+        z = self._act_fn_call(wz(z) + wx(x))
+      else:
+        z = self._act_fn_call(wz(z))
+
+    if self._resnet:
+      z = x + z
+
+    return z.squeeze(0) if squeeze else z
+
+  @property
+  def is_potential(self) -> bool:
+    """KeyNet models a potential via f(x) = <gradient(x), x>."""
     return True

--- a/src/ott/neural/networks/layers/posdef.py
+++ b/src/ott/neural/networks/layers/posdef.py
@@ -11,204 +11,204 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Optional, Tuple
+"""Positive-weight dense layer for input convex neural networks."""
+
+from typing import Callable, Optional
 
 import jax
 import jax.numpy as jnp
 
-from flax import linen as nn
+from flax import nnx
 
 __all__ = ["PositiveDense", "PosDefPotentials"]
 
-PRNGKey = jax.Array
-Shape = Tuple[int, ...]
-Dtype = Any
-Array = jnp.ndarray
-
-DEFAULT_KERNEL_INIT = lambda *a, **k: nn.initializers.lecun_normal()(*a, **k)
-DEFAULT_BIAS_INIT = nn.initializers.zeros
-DEFAULT_RECTIFIER = nn.activation.relu
+DEFAULT_KERNEL_INIT = nnx.initializers.lecun_normal()
+DEFAULT_BIAS_INIT = nnx.initializers.zeros_init()
+DEFAULT_DIAG_INIT = nnx.initializers.constant(-2.0)
 
 
-class PositiveDense(nn.Module):
-  """A linear transformation using a matrix with all entries non-negative.
+def _sinkhorn_normalize(
+    log_kernel: jax.Array,
+    num_iter: int = 10,
+    epsilon: float = 0.1,
+) -> jax.Array:
+  """Sinkhorn normalization in log-space for positive weight matrices."""
+  log_k = log_kernel / epsilon
+
+  def body_fn(carry, _):
+    log_u, log_v = carry
+    log_u = -jax.nn.logsumexp(log_k + log_v[None, :], axis=1)
+    log_v = -jax.nn.logsumexp(log_k + log_u[:, None], axis=0)
+    return (log_u, log_v), None
+
+  d_in, d_out = log_kernel.shape
+  log_u = jnp.zeros(d_in)
+  log_v = jnp.zeros(d_out)
+  (log_u, log_v), _ = jax.lax.scan(
+      body_fn, (log_u, log_v), None, length=num_iter
+  )
+  return jnp.exp(log_k + log_u[:, None] + log_v[None, :])
+
+
+class PositiveDense(nnx.Module):
+  """A linear transformation with non-negative weights.
+
+  Three modes for enforcing positivity:
+
+  - **Element-wise rectifier** (default): applies ``rectifier_fn``
+    (e.g., softplus, relu) to each weight independently.
+  - **Softmax** (``use_softmax=True``): column-wise softmax so each
+    column sums to 1, producing stochastic weight matrices.
+  - **Sinkhorn** (``use_sinkhorn=True``): Sinkhorn normalization in
+    log-space produces approximately doubly-stochastic matrices.
 
   Args:
-    dim_hidden: Number of output dimensions.
-    rectifier_fn: Rectifier function. The default is
-      :func:`~flax.linen.activation.relu`.
-    use_bias: Whether to add bias to the output.
-    kernel_init: Initializer for the matrix. The default is
-      :func:`~flax.linen.initializers.lecun_normal`.
-    bias_init: Initializer for the bias. The default is
-      :func:`~flax.linen.initializers.zeros`.
-    precision: Numerical precision of the computation.
+    in_features: Input dimension.
+    out_features: Output dimension.
+    rectifier_fn: Function to enforce non-negativity. Ignored when
+      ``use_softmax`` or ``use_sinkhorn`` is True.
+    use_softmax: If True, use column-wise softmax normalization.
+    use_sinkhorn: If True, use Sinkhorn normalization.
+    use_bias: Whether to add a bias term.
+    kernel_init: Initializer for the kernel.
+    bias_init: Initializer for the bias.
+    rngs: Random number generators.
   """
 
-  dim_hidden: int
-  rectifier_fn: Callable[[Array], Array] = DEFAULT_RECTIFIER
-  use_bias: bool = True
-  kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = DEFAULT_KERNEL_INIT
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = DEFAULT_BIAS_INIT
-  precision: Optional[jax.lax.Precision] = None
-
-  @nn.compact
-  def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
-    """Applies a linear transformation to x along the last dimension.
-
-    Args:
-      x: Array of shape ``[batch, ..., features]``.
-
-    Returns:
-      Array of shape ``[batch, ..., dim_hidden]``.
-    """
-    # TODO(michalk8): update when refactoring neuraldual
-    # assert x.ndim > 1, x.ndim
-
-    kernel = self.param(
-        "kernel", self.kernel_init, (x.shape[-1], self.dim_hidden)
+  def __init__(
+      self,
+      in_features: int,
+      out_features: int,
+      *,
+      rectifier_fn: Optional[Callable[[jax.Array],
+                                      jax.Array]] = jax.nn.softplus,
+      use_softmax: bool = False,
+      use_sinkhorn: bool = False,
+      use_bias: bool = True,
+      kernel_init: nnx.initializers.Initializer = DEFAULT_KERNEL_INIT,
+      bias_init: nnx.initializers.Initializer = DEFAULT_BIAS_INIT,
+      rngs: nnx.Rngs,
+  ):
+    self.rectifier_fn = rectifier_fn
+    self.use_softmax = use_softmax
+    self.use_sinkhorn = use_sinkhorn
+    if out_features == 1 and use_sinkhorn:
+      self.use_sinkhorn = False
+      self.use_softmax = True
+    self.kernel = nnx.Param(
+        kernel_init(rngs.params(), (in_features, out_features))
     )
-    kernel = self.rectifier_fn(kernel)
+    self.bias = (
+        nnx.Param(bias_init(rngs.params(),
+                            (out_features,))) if use_bias else None
+    )
 
-    x = jnp.tensordot(x, kernel, axes=(-1, 0), precision=self.precision)
-    if self.use_bias:
-      x = x + self.param("bias", self.bias_init, (self.dim_hidden,))
+  def __call__(self, x: jax.Array) -> jax.Array:
+    """Apply positive-weight linear transformation."""
+    kernel = self._get_positive_kernel()
+    out = x @ kernel
+    if self.bias is not None:
+      out = out + self.bias[...]
+    return out
 
-    return x
+  def _get_positive_kernel(self) -> jax.Array:
+    """Get the positive kernel via the configured normalization."""
+    raw = self.kernel[...]
+    if self.use_sinkhorn:
+      return _sinkhorn_normalize(jnp.clip(raw, -5.0, 5.0))
+    if self.use_softmax:
+      return jax.nn.softmax(raw, axis=0)
+    return self.rectifier_fn(raw)
 
 
-class PosDefPotentials(nn.Module):
-  r""":math:`\frac{1}{2} x^T (A_i A_i^T + \text{Diag}(d_i)) x + b_i^T x^2 + c_i`
-    potentials.
+class PosDefPotentials(nnx.Module):
+  """Low-rank plus diagonal positive definite quadratic potentials.
 
-  This class implements a layer that takes (batched) ``d``-dimensional vectors
-  ``x`` in, to output a ``num_potentials``-dimensional vector. Each of the
-  entries in that output is a positive definite quadratic form evaluated at
-  ``x``; each of these quadratic terms is parameterized as a low-rank plus
-  diagonal matrix. The low-rank term is parameterized as :math:`A_i A_i^T`,
-  where each of these matrices is of size ``(rank, d)``. Taken together,
-  these matrices form a tensor ``(num_potentials, rank, d)``.
-  The diagonal terms :math:`d_i` form a ``(num_potentials, d)`` matrix of
-  positive values; the linear terms :math:`b_i` form a ``(num_potentials, d)``
-  matrix. Finally, the :math:`c_i` are contained in a vector of size
-  ``(num_potentials,)``.
+  Computes: sum_i 0.5 * x^T (A_i A_i^T + diag(d_i)) x + b_i^T x + c_i
+
+  This is used as an optional additive term in the ICNN to ensure
+  strong convexity.
 
   Args:
-    num_potentials: Dimension of the output.
-    rank: Rank of the matrices :math:`A_i` used as low-rank factors
-      for the quadratic potentials.
-    rectifier_fn: Rectifier function to ensure non-negativity of the diagonals
-      :math:`d_i`. The default is :func:`~flax.linen.activation.relu`.
-    use_linear: Whether to add a linear layers :math:`b_i` to the outputs.
-    use_bias: Whether to add biases :math:`c_i` to the outputs.
-    kernel_lr_init: Initializer for the matrices :math:`A_i`
-      of the quadratic potentials when ``rank > 0``.
-      The default is :func:`~flax.linen.initializers.lecun_normal`.
-    kernel_diag_init: Initializer for the diagonals :math:`d_i`.
-      The default is :func:`~flax.linen.initializers.ones`.
-    kernel_linear_init: Initializer for the linear layers :math:`b_i`.
-      The default is :func:`~flax.linen.initializers.lecun_normal`.
-    bias_init: Initializer for the bias. The default is
-      :func:`~flax.linen.initializers.zeros`.
-    precision: Numerical precision of the computation.
-  """  # noqa: D205,E501
+    in_features: Input dimension.
+    num_potentials: Number of output potentials.
+    rank: Rank of the low-rank factors A_i.
+    use_linear: Whether to include the linear term b^T x.
+    use_bias: Whether to include the scalar bias c.
+    rngs: Random number generators.
+  """
 
-  num_potentials: int
-  rank: int = 0
-  rectifier_fn: Callable[[Array], Array] = DEFAULT_RECTIFIER
-  use_linear: bool = True
-  use_bias: bool = True
-  kernel_lr_init: Callable[[PRNGKey, Shape, Dtype], Array] = DEFAULT_KERNEL_INIT
-  kernel_diag_init: Callable[[PRNGKey, Shape, Dtype],
-                             Array] = nn.initializers.ones
-  kernel_linear_init: Callable[[PRNGKey, Shape, Dtype],
-                               Array] = DEFAULT_KERNEL_INIT
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = DEFAULT_BIAS_INIT
-  precision: Optional[jax.lax.Precision] = None
+  def __init__(
+      self,
+      in_features: int,
+      num_potentials: int,
+      *,
+      rank: int = 1,
+      use_linear: bool = True,
+      use_bias: bool = True,
+      kernel_diag_init: nnx.initializers.Initializer = DEFAULT_DIAG_INIT,
+      kernel_lr_init: nnx.initializers.Initializer = DEFAULT_KERNEL_INIT,
+      kernel_linear_init: nnx.initializers.Initializer = DEFAULT_KERNEL_INIT,
+      bias_init: nnx.initializers.Initializer = DEFAULT_BIAS_INIT,
+      rectifier_fn: Callable[[jax.Array], jax.Array] = jax.nn.softplus,
+      rngs: nnx.Rngs,
+  ):
+    self.rectifier_fn = rectifier_fn
+    self.num_potentials = num_potentials
 
-  @nn.compact
-  def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
-    """Compute quadratic forms of the input.
-
-    Args:
-      x: Array of shape ``[batch, ..., features]``.
-
-    Returns:
-      Array of shape ``[batch, ..., num_potentials]``.
-    """
-    # TODO(michalk8): update when refactoring neuraldual
-    # assert x.ndim > 1, x.ndim
-
-    dim_data = x.shape[-1]
-    x = x.reshape((-1, dim_data))
-
-    diag_kernel = self.param(
-        "diag_kernel", self.kernel_diag_init, (dim_data, self.num_potentials)
+    # Diagonal: [num_potentials, in_features]
+    self.kernel_diag = nnx.Param(
+        kernel_diag_init(rngs.params(), (num_potentials, in_features))
     )
-    # ensures the diag_kernel parameter stays non negative
-    diag_kernel = self.rectifier_fn(diag_kernel)
-
-    # (batch, dim_data, 1), (1, dim_data, num_potentials)
-    y = 0.5 * jnp.sum(((x ** 2)[..., None] * diag_kernel[None]), axis=1)
-
-    if self.rank > 0:
-      quad_kernel = self.param(
-          "quad_kernel", self.kernel_lr_init,
-          (self.num_potentials, dim_data, self.rank)
-      )
-      # (batch, num_potentials, rank)
-      quad = 0.5 * jnp.tensordot(
-          x, quad_kernel, axes=(-1, 1), precision=self.precision
-      ) ** 2
-      y = y + jnp.sum(quad, axis=-1)
-
-    if self.use_linear:
-      linear_kernel = self.param(
-          "lin_kernel", self.kernel_linear_init,
-          (dim_data, self.num_potentials)
-      )
-      y = y + jnp.dot(x, linear_kernel, precision=self.precision)
-
-    if self.use_bias:
-      y = y + self.param("bias", self.bias_init, (self.num_potentials,))
-
-    return y
-
-  @classmethod
-  def init_from_samples(
-      cls, source: jnp.ndarray, target: jnp.ndarray, **kwargs: Any
-  ) -> "PosDefPotentials":
-    """Initialize the layer using Gaussian approximation :cite:`bunne:22`.
-
-    Args:
-      source: Samples from the source distribution, array of shape ``[n, d]``.
-      target: Samples from the target distribution, array of shape ``[m, d]``.
-      kwargs: Keyword arguments for initialization. Note that ``use_linear``
-        will be always set to :obj:`True`.
-
-    Returns:
-      The layer with fixed linear and quadratic initialization.
-    """
-    factor, mean = _compute_gaussian_map_params(source, target)
-
-    kwargs["use_linear"] = True
-    return cls(
-        kernel_lr_init=lambda *_, **__: factor,
-        kernel_linear_init=lambda *_, **__: mean.T,
-        **kwargs,
+    # Low-rank factors: [num_potentials, in_features, rank]
+    self.kernel_lr = nnx.Param(
+        kernel_lr_init(rngs.params(), (num_potentials, in_features, rank))
+    )
+    # Linear term: [num_potentials, in_features]
+    self.kernel_linear = (
+        nnx.Param(
+            kernel_linear_init(rngs.params(), (num_potentials, in_features))
+        ) if use_linear else None
+    )
+    # Bias: [num_potentials]
+    self.bias = (
+        nnx.Param(bias_init(rngs.params(),
+                            (num_potentials,))) if use_bias else None
     )
 
+  def __call__(self, x: jax.Array) -> jax.Array:
+    """Evaluate positive definite quadratic potentials.
 
-def _compute_gaussian_map_params(
-    source: jnp.ndarray, target: jnp.ndarray
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
-  from ott.math import matrix_square_root
-  from ott.tools.gaussian_mixture import gaussian
+    Args:
+      x: Input array of shape ``[..., in_features]``.
 
-  g_s = gaussian.Gaussian.from_samples(source)
-  g_t = gaussian.Gaussian.from_samples(target)
-  lin_op = g_s.scale.gaussian_map(g_t.scale)
-  b = jnp.squeeze(g_t.loc) - lin_op @ jnp.squeeze(g_s.loc)
-  lin_op = matrix_square_root.sqrtm_only(lin_op)
+    Returns:
+      Output array of shape ``[..., num_potentials]``.
+    """
+    # Quadratic term: 0.5 * x^T (A A^T + diag(d)) x
+    diag = self.rectifier_fn(self.kernel_diag[...])  # [n_pot, d]
+    lr = self.kernel_lr[...]  # [n_pot, d, rank]
 
-  return jnp.expand_dims(lin_op, 0), jnp.expand_dims(b, 0)
+    # x: [..., d] -> [..., 1, d]
+    x_expanded = x[..., None, :]
+
+    # Diagonal part: sum_d x_d^2 * diag_d -> [..., n_pot]
+    quad_diag = jnp.sum(x_expanded ** 2 * diag, axis=-1)
+
+    # Low-rank part: ||A^T x||^2 -> [..., n_pot]
+    # x_expanded: [..., 1, d], lr: [n_pot, d, rank]
+    atx = jnp.einsum("...d,ndr->...nr", x, lr)  # [..., n_pot, rank]
+    quad_lr = jnp.sum(atx ** 2, axis=-1)  # [..., n_pot]
+
+    out = 0.5 * (quad_diag + quad_lr)
+
+    # Linear term
+    if self.kernel_linear is not None:
+      linear = jnp.einsum("...d,nd->...n", x, self.kernel_linear[...])
+      out = out + linear
+
+    # Bias
+    if self.bias is not None:
+      out = out + self.bias[...]
+
+    return out

--- a/tests/geometry/pallas_kernels_test.py
+++ b/tests/geometry/pallas_kernels_test.py
@@ -1,0 +1,368 @@
+# Copyright OTT-JAX
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Pallas Sinkhorn kernels (GPU only).
+
+Run with::
+
+    pytest tests/geometry/pallas_kernels_test.py -v
+
+Tests are skipped automatically when Pallas is unavailable or no GPU is
+present.
+"""
+import pytest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from ott.geometry import costs, geometry, low_rank, pointcloud
+
+# ---------------------------------------------------------------------------
+# Skip helpers
+# ---------------------------------------------------------------------------
+
+
+def _pallas_available() -> bool:
+  try:
+    import jax.experimental.pallas as pl  # noqa: F401
+
+    from ott.geometry._pallas_kernels import (  # noqa: F401
+        apply_kernel_pallas,
+        apply_lse_kernel_pallas,
+    )
+
+    # Actually trigger compilation to check GPU support.
+    return jax.default_backend() == "gpu"
+  except Exception:
+    return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pallas_available(),
+    reason="Pallas not available or no GPU detected",
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_lrc(rng, n, m, r, eps=0.1, bias=0.0):
+  rngs = jax.random.split(rng, 4)
+  c1 = jax.random.normal(rngs[0], (n, r))
+  c2 = jax.random.normal(rngs[1], (m, r))
+  f = jax.random.normal(rngs[2], (n,))
+  g = jax.random.normal(rngs[3], (m,))
+  lrc = low_rank.LRCGeometry(c1, c2, bias=bias, epsilon=eps)
+  return lrc, f, g
+
+
+def _ref_lse(lrc, f, g, eps, vec=None, axis=0):
+  """Dense reference: materialise cost matrix, then logsumexp."""
+  C = lrc.cost_matrix  # [n, m]
+  bi = lrc.bias
+  if axis == 0:
+    # sum over source i, result for target j
+    logit = (f[:, None] + g[None, :] - C - bi) / eps  # [n, m]
+    if vec is None:
+      from jax.scipy.special import logsumexp
+      lse = logsumexp(logit, axis=0)  # [m]
+      return eps * lse - g, jnp.array([1.0])
+    else:
+      from ott.math import utils as mu
+      res, sgn = mu.logsumexp(logit, b=vec[:, None].T, axis=0, return_sign=True)
+      # wait, vec is [n], sum over i
+      # manual: for each j, logsumexp_i(logit[:,j], b=vec)
+      import jax.numpy as jnp
+
+      def one_j(logit_col):  # [n]
+        from ott.math import utils as mu
+        r, s = mu.logsumexp(logit_col, b=vec, return_sign=True)
+        return r, s
+
+      res_j, sgn_j = jax.vmap(one_j)(logit.T)  # vmap over j
+      return eps * res_j - jnp.where(jnp.isfinite(g), g, 0.0), sgn_j
+  else:
+    logit = (f[:, None] + g[None, :] - C - bi) / eps  # [n, m]
+    if vec is None:
+      from jax.scipy.special import logsumexp
+      lse = logsumexp(logit, axis=1)  # [n]
+      return eps * lse - f, jnp.array([1.0])
+    else:
+      import jax.numpy as jnp
+
+      def one_i(logit_row):  # [m]
+        from ott.math import utils as mu
+        r, s = mu.logsumexp(logit_row, b=vec, return_sign=True)
+        return r, s
+
+      res_i, sgn_i = jax.vmap(one_i)(logit)  # vmap over i
+      return eps * res_i - jnp.where(jnp.isfinite(f), f, 0.0), sgn_i
+
+
+def _ref_kernel(lrc, vec, eps, axis=1):
+  K = jnp.exp(-lrc.cost_matrix / eps)
+  return K @ vec if axis == 1 else K.T @ vec
+
+
+# ---------------------------------------------------------------------------
+# apply_lse_kernel_pallas
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLSEKernelPallas:
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  @pytest.mark.parametrize("r", [32, 64, 100])
+  def test_lse_no_vec_matches_dense(self, rng: jax.Array, axis: int, r: int):
+    """apply_lse_kernel_pallas (vec=None) matches dense reference."""
+    from ott.geometry._pallas_kernels import apply_lse_kernel_pallas
+    n, m, eps = 128, 192, 0.1
+    lrc, f, g = _make_lrc(rng, n, m, r, eps)
+
+    ref, _ = _ref_lse(lrc, f, g, eps, vec=None, axis=axis)
+    got, sgn = apply_lse_kernel_pallas(
+        lrc.cost_1, lrc.cost_2, f, g, eps, lrc.bias, None, axis
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+    assert float(sgn[0]) == pytest.approx(1.0)
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  def test_lse_with_vec_matches_dense(self, rng: jax.Array, axis: int):
+    """Signed weighted logsumexp matches dense reference."""
+    from ott.geometry._pallas_kernels import apply_lse_kernel_pallas
+    n, m, r, eps = 128, 192, 64, 0.1
+    lrc, f, g = _make_lrc(rng, n, m, r, eps)
+    rngs = jax.random.split(rng, 2)
+    # positive vec — sign should be +1 everywhere
+    vec_src = jnp.abs(jax.random.normal(rngs[0], (n,))) + 0.1
+    vec_tgt = jnp.abs(jax.random.normal(rngs[1], (m,))) + 0.1
+    vec = vec_src if axis == 0 else vec_tgt
+
+    ref, ref_sgn = _ref_lse(lrc, f, g, eps, vec=vec, axis=axis)
+    got, got_sgn = apply_lse_kernel_pallas(
+        lrc.cost_1, lrc.cost_2, f, g, eps, lrc.bias, vec, axis
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-3, atol=1e-3
+    )
+    np.testing.assert_array_equal(
+        np.sign(np.asarray(got_sgn)), np.sign(np.asarray(ref_sgn))
+    )
+
+  def test_lse_nonmultiple_sizes(self, rng: jax.Array):
+    """Padding handles n, m not divisible by block size."""
+    from ott.geometry._pallas_kernels import apply_lse_kernel_pallas
+    n, m, r, eps = 100, 150, 37, 0.1  # 100 % 64 != 0
+    lrc, f, g = _make_lrc(rng, n, m, r, eps)
+
+    ref, _ = _ref_lse(lrc, f, g, eps, vec=None, axis=0)
+    got, _ = apply_lse_kernel_pallas(
+        lrc.cost_1, lrc.cost_2, f, g, eps, lrc.bias, None, 0, BM=64, BN=64
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  def test_lse_nonzero_bias(self, rng: jax.Array):
+    """Constant bias in LRCGeometry is handled correctly."""
+    from ott.geometry._pallas_kernels import apply_lse_kernel_pallas
+    n, m, r, eps = 128, 128, 64, 0.1
+    lrc, f, g = _make_lrc(rng, n, m, r, eps, bias=0.5)
+
+    ref, _ = _ref_lse(lrc, f, g, eps, vec=None, axis=0)
+    got, _ = apply_lse_kernel_pallas(
+        lrc.cost_1, lrc.cost_2, f, g, eps, lrc.bias, None, 0
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  def test_lrcgeometry_apply_lse_kernel(self, rng: jax.Array, axis: int):
+    """LRCGeometry.apply_lse_kernel auto-uses Pallas and matches dense."""
+    n, m, r, eps = 128, 192, 64, 0.1
+    lrc, f, g = _make_lrc(rng, n, m, r, eps)
+
+    ref_geom = geometry.Geometry(lrc.cost_matrix, epsilon=eps)
+    ref, _ = ref_geom.apply_lse_kernel(f, g, eps, axis=axis)
+    got, _ = lrc.apply_lse_kernel(f, g, eps, axis=axis)
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  def test_pointcloud_negdotp_apply_lse_kernel(self, rng: jax.Array, axis: int):
+    """PointCloud (NegDotProduct, online) delegates to Pallas."""
+    n, m, d, eps = 128, 192, 64, 0.1
+    rngs = jax.random.split(rng, 4)
+    x = jax.random.normal(rngs[0], (n, d))
+    y = jax.random.normal(rngs[1], (m, d))
+    f = jax.random.normal(rngs[2], (n,))
+    g = jax.random.normal(rngs[3], (m,))
+
+    pc_ref = pointcloud.PointCloud(
+        x, y, cost_fn=costs.NegDotProduct(), batch_size=None, epsilon=eps
+    )
+    ref, _ = pc_ref.apply_lse_kernel(f, g, eps, axis=axis)
+
+    pc_pallas = pointcloud.PointCloud(
+        x, y, cost_fn=costs.NegDotProduct(), batch_size=n, epsilon=eps
+    )
+    got, _ = pc_pallas.apply_lse_kernel(f, g, eps, axis=axis)
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-3, atol=1e-3
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_kernel_pallas
+# ---------------------------------------------------------------------------
+
+
+class TestApplyKernelPallas:
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  @pytest.mark.parametrize("r", [32, 64, 100])
+  def test_kernel_matches_dense(self, rng: jax.Array, axis: int, r: int):
+    """apply_kernel_pallas matches dense K @ vec."""
+    from ott.geometry._pallas_kernels import apply_kernel_pallas
+    n, m, eps = 128, 192, 0.1
+    lrc, _, _ = _make_lrc(rng, n, m, r, eps)
+    rngs = jax.random.split(rng, 1)
+    vec_size = n if axis == 0 else m
+    vec = jax.random.normal(rngs[0], (vec_size,))
+
+    ref = _ref_kernel(lrc, vec, eps, axis)
+    got = apply_kernel_pallas(lrc.cost_1, lrc.cost_2, vec, eps, lrc.bias, axis)
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  def test_kernel_nonmultiple_sizes(self, rng: jax.Array):
+    """Masking + padding handles non-divisible sizes correctly."""
+    from ott.geometry._pallas_kernels import apply_kernel_pallas
+    n, m, r, eps = 100, 150, 37, 0.1
+    lrc, _, _ = _make_lrc(rng, n, m, r, eps)
+    rngs = jax.random.split(rng, 1)
+    vec = jax.random.normal(rngs[0], (m,))
+
+    ref = _ref_kernel(lrc, vec, eps, axis=1)
+    got = apply_kernel_pallas(
+        lrc.cost_1, lrc.cost_2, vec, eps, lrc.bias, axis=1, BN=64, BM=64
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  def test_kernel_nonzero_bias(self, rng: jax.Array):
+    from ott.geometry._pallas_kernels import apply_kernel_pallas
+    n, m, r, eps = 128, 128, 64, 0.1
+    lrc, _, _ = _make_lrc(rng, n, m, r, eps, bias=0.5)
+    rngs = jax.random.split(rng, 1)
+    vec = jax.random.normal(rngs[0], (m,))
+
+    ref = _ref_kernel(lrc, vec, eps, axis=1)
+    got = apply_kernel_pallas(
+        lrc.cost_1, lrc.cost_2, vec, eps, lrc.bias, axis=1
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  def test_lrcgeometry_apply_kernel(self, rng: jax.Array, axis: int):
+    """LRCGeometry.apply_kernel auto-uses Pallas."""
+    n, m, r, eps = 128, 192, 64, 0.1
+    lrc, _, _ = _make_lrc(rng, n, m, r, eps)
+    rngs = jax.random.split(rng, 1)
+    vec_size = n if axis == 0 else m
+    vec = jax.random.normal(rngs[0], (vec_size,))
+
+    ref = _ref_kernel(lrc, vec, eps, axis)
+    got = lrc.apply_kernel(vec, eps=eps, axis=axis)
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-4, atol=1e-4
+    )
+
+  @pytest.mark.parametrize("axis", [0, 1])
+  def test_pointcloud_negdotp_apply_kernel(self, rng: jax.Array, axis: int):
+    """PointCloud (NegDotProduct, online) delegates apply_kernel to Pallas."""
+    n, m, d, eps = 128, 192, 64, 0.1
+    rngs = jax.random.split(rng, 2)
+    x = jax.random.normal(rngs[0], (n, d))
+    y = jax.random.normal(rngs[1], (m, d))
+    vec_size = n if axis == 0 else m
+    vec = jax.random.normal(jax.random.key(99), (vec_size,))
+
+    pc_ref = pointcloud.PointCloud(
+        x, y, cost_fn=costs.NegDotProduct(), batch_size=None, epsilon=eps
+    )
+    ref = pc_ref.apply_kernel(vec, eps=eps, axis=axis)
+
+    pc_pallas = pointcloud.PointCloud(
+        x, y, cost_fn=costs.NegDotProduct(), batch_size=n, epsilon=eps
+    )
+    got = pc_pallas.apply_kernel(vec, eps=eps, axis=axis)
+
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(ref), rtol=1e-3, atol=1e-3
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sinkhorn end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestSinkhornPallas:
+
+  @pytest.mark.parametrize("lse_mode", [True, False])
+  def test_sinkhorn_matches_reference(self, rng: jax.Array, lse_mode: bool):
+    """Full Sinkhorn solve via Pallas matches the dense reference."""
+    from ott.solvers import linear
+
+    n, m, d, eps = 128, 192, 64, 0.1
+    rngs = jax.random.split(rng, 2)
+    x = jax.random.normal(rngs[0], (n, d))
+    y = jax.random.normal(rngs[1], (m, d))
+
+    geom_ref = pointcloud.PointCloud(
+        x, y, cost_fn=costs.NegDotProduct(), batch_size=None, epsilon=eps
+    )
+    geom_pal = pointcloud.PointCloud(
+        x, y, cost_fn=costs.NegDotProduct(), batch_size=n, epsilon=eps
+    )
+
+    out_ref = linear.solve(geom_ref, lse_mode=lse_mode)
+    out_pal = linear.solve(geom_pal, lse_mode=lse_mode)
+
+    np.testing.assert_allclose(
+        float(out_pal.reg_ot_cost),
+        float(out_ref.reg_ot_cost),
+        rtol=1e-3,
+        atol=1e-3,
+    )

--- a/tests/neural/methods/neuraldual_test.py
+++ b/tests/neural/methods/neuraldual_test.py
@@ -18,6 +18,8 @@ import pytest
 import jax
 import numpy as np
 
+from flax import nnx
+
 from ott import datasets
 from ott.neural.methods import neuraldual
 from ott.neural.networks import icnn, potentials
@@ -41,8 +43,8 @@ def ds(rng: jax.Array, request: Tuple[str, str]) -> DatasetPair_t:
 def neural_models(request: str) -> ModelPair_t:
   if request.param == "icnns":
     return (
-        icnn.ICNN(dim_data=2,
-                  dim_hidden=[32]), icnn.ICNN(dim_data=2, dim_hidden=[32])
+        icnn.ICNN(input_dim=2, dim_hidden=[32], rngs=nnx.Rngs(0)),
+        icnn.ICNN(input_dim=2, dim_hidden=[32], rngs=nnx.Rngs(1))
     )
   if request.param == "mlps":
     return potentials.PotentialMLP(dim_hidden=[32]
@@ -58,9 +60,9 @@ def neural_models(request: str) -> ModelPair_t:
 class TestNeuralDual:
 
   @pytest.mark.fast.with_args(
-      "back_and_forth,test_gaussian_init,amortization_loss,conjugate_solver", (
-          (True, True, "objective", conjugate.DEFAULT_CONJUGATE_SOLVER),
-          (False, False, "regression", None),
+      "back_and_forth,amortization_loss,conjugate_solver", (
+          (True, "objective", conjugate.DEFAULT_CONJUGATE_SOLVER),
+          (False, "regression", None),
       ),
       only_fast=0
   )
@@ -70,7 +72,6 @@ class TestNeuralDual:
       neural_models: ModelPair_t,
       back_and_forth: bool,
       amortization_loss: str,
-      test_gaussian_init: bool,
       conjugate_solver: Optional[conjugate.FenchelConjugateSolver],
   ):
     """Tests convergence of learning the Kantorovich dual using ICNNs."""
@@ -85,25 +86,7 @@ class TestNeuralDual:
 
     train_dataset, valid_dataset = ds
 
-    if test_gaussian_init:
-      neural_f = icnn.ICNN(
-          dim_data=2,
-          dim_hidden=[32],
-          gaussian_map_samples=[
-              next(train_dataset.source_iter),
-              next(train_dataset.target_iter)
-          ]
-      )
-      neural_g = icnn.ICNN(
-          dim_data=2,
-          dim_hidden=[32],
-          gaussian_map_samples=[
-              next(train_dataset.target_iter),
-              next(train_dataset.source_iter)
-          ]
-      )
-    else:
-      neural_f, neural_g = neural_models
+    neural_f, neural_g = neural_models
 
     # initialize neural dual
     neural_dual_solver = neuraldual.W2NeuralDual(

--- a/tests/neural/networks/icnn_test.py
+++ b/tests/neural/networks/icnn_test.py
@@ -30,7 +30,7 @@ class TestICNN:
     n_samples, n_features = 10, 2
     dim_hidden = (64, 64)
 
-    model = icnn.ICNN(dim_hidden, rngs=nnx.Rngs(0))
+    model = icnn.ICNN(dim_hidden, input_dim=n_features, rngs=nnx.Rngs(0))
 
     rng1, rng2 = jax.random.split(rng, 2)
     x = jax.random.normal(rng1, (n_samples, n_features)) * 0.1
@@ -50,11 +50,9 @@ class TestICNN:
     """Tests if Hessian of ICNN is positive-semidefinite."""
     n_features = 2
     dim_hidden = (64, 64)
-    model = icnn.ICNN(dim_hidden, rngs=nnx.Rngs(0))
+    model = icnn.ICNN(dim_hidden, input_dim=n_features, rngs=nnx.Rngs(0))
 
     rng1, rng2 = jax.random.split(rng)
-    # Trigger lazy init
-    _ = model(jax.random.normal(rng1, (1, n_features)))
 
     data = jax.random.normal(rng2, (n_features,))
 
@@ -69,7 +67,12 @@ class TestICNN:
     n_samples, n_features, output_dim = 10, 3, 4
     dim_hidden = (32, 32)
 
-    model = icnn.ICNN(dim_hidden, output_dim=output_dim, rngs=nnx.Rngs(0))
+    model = icnn.ICNN(
+        dim_hidden,
+        input_dim=n_features,
+        output_dim=output_dim,
+        rngs=nnx.Rngs(0)
+    )
 
     x = jax.random.normal(rng, (n_samples, n_features))
     out = model(x)
@@ -80,7 +83,9 @@ class TestICNN:
     n_features = 4
     dim_hidden = (32, 32, 32, 32)
 
-    model = icnn.ICNN(dim_hidden, wx_inject=2, rngs=nnx.Rngs(0))
+    model = icnn.ICNN(
+        dim_hidden, input_dim=n_features, wx_inject=2, rngs=nnx.Rngs(0)
+    )
     x = jax.random.normal(rng, (5, n_features))
     out = model(x)
     assert out.shape == (5,)
@@ -90,7 +95,9 @@ class TestICNN:
     n_features = 3
     dim_hidden = (32, 32)
 
-    model = icnn.ICNN(dim_hidden, pos_def_rank=2, rngs=nnx.Rngs(0))
+    model = icnn.ICNN(
+        dim_hidden, input_dim=n_features, pos_def_rank=2, rngs=nnx.Rngs(0)
+    )
     x = jax.random.normal(rng, (5, n_features))
     out = model(x)
     assert out.shape == (5,)
@@ -105,7 +112,9 @@ class TestICNN:
         "use_softmax": mode == "softmax",
         "use_sinkhorn": mode == "sinkhorn",
     }
-    model = icnn.ICNN(dim_hidden, rngs=nnx.Rngs(0), **kwargs)
+    model = icnn.ICNN(
+        dim_hidden, input_dim=n_features, rngs=nnx.Rngs(0), **kwargs
+    )
 
     rng1, rng2 = jax.random.split(rng)
     x = jax.random.normal(rng1, (n_samples, n_features)) * 0.1
@@ -132,7 +141,7 @@ class TestKeyNet:
     n_samples, n_features = 10, 4
     dim_hidden = (32, 32)
 
-    model = icnn.KeyNet(dim_hidden, rngs=nnx.Rngs(0))
+    model = icnn.KeyNet(dim_hidden, input_dim=n_features, rngs=nnx.Rngs(0))
     x = jax.random.normal(rng, (n_samples, n_features))
 
     # gradient returns vectors
@@ -148,7 +157,9 @@ class TestKeyNet:
     n_features = 4
     dim_hidden = (32, 32)
 
-    model = icnn.KeyNet(dim_hidden, resnet=True, rngs=nnx.Rngs(0))
+    model = icnn.KeyNet(
+        dim_hidden, input_dim=n_features, resnet=True, rngs=nnx.Rngs(0)
+    )
     x = jax.random.normal(rng, (5, n_features))
 
     grad_out = model.gradient(x)
@@ -160,7 +171,12 @@ class TestKeyNet:
     output_dim = 8
     dim_hidden = (32, 32)
 
-    model = icnn.KeyNet(dim_hidden, output_dim=output_dim, rngs=nnx.Rngs(0))
+    model = icnn.KeyNet(
+        dim_hidden,
+        input_dim=n_features,
+        output_dim=output_dim,
+        rngs=nnx.Rngs(0)
+    )
     x = jax.random.normal(rng, (5, n_features))
 
     grad_out = model.gradient(x)
@@ -171,7 +187,7 @@ class TestKeyNet:
     n_features = 4
     dim_hidden = (32, 32)
 
-    model = icnn.KeyNet(dim_hidden, rngs=nnx.Rngs(0))
+    model = icnn.KeyNet(dim_hidden, input_dim=n_features, rngs=nnx.Rngs(0))
     x = jax.random.normal(rng, (n_features,))
 
     grad_out = model.gradient(x)

--- a/tests/neural/networks/icnn_test.py
+++ b/tests/neural/networks/icnn_test.py
@@ -17,6 +17,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from flax import nnx
+
 from ott.neural.networks import icnn
 
 
@@ -28,45 +30,152 @@ class TestICNN:
     n_samples, n_features = 10, 2
     dim_hidden = (64, 64)
 
-    # define icnn model
-    model = icnn.ICNN(n_features, dim_hidden=dim_hidden)
+    model = icnn.ICNN(dim_hidden, rngs=nnx.Rngs(0))
 
-    # initialize model
     rng1, rng2 = jax.random.split(rng, 2)
-    params = model.init(rng1, jnp.ones((1, n_features)))
-
-    # check convexity
     x = jax.random.normal(rng1, (n_samples, n_features)) * 0.1
     y = jax.random.normal(rng2, (n_samples, n_features))
 
-    out_x = model.apply(params, x)
-    out_y = model.apply(params, y)
+    out_x = model(x)
+    out_y = model(y)
 
     out = []
     for t in jnp.linspace(0, 1):
-      out_xy = model.apply(params, t * x + (1 - t) * y)
+      out_xy = model(t * x + (1 - t) * y)
       out.append((t * out_x + (1 - t) * out_y) - out_xy)
 
     np.testing.assert_array_equal(np.array(out) >= 0.0, True)
 
   def test_icnn_hessian(self, rng: jax.Array):
     """Tests if Hessian of ICNN is positive-semidefinite."""
-
-    # define icnn model
     n_features = 2
     dim_hidden = (64, 64)
-    model = icnn.ICNN(n_features, dim_hidden=dim_hidden)
+    model = icnn.ICNN(dim_hidden, rngs=nnx.Rngs(0))
 
-    # initialize model
     rng1, rng2 = jax.random.split(rng)
-    params = model.init(rng1, jnp.ones((1, n_features)))
+    # Trigger lazy init
+    _ = model(jax.random.normal(rng1, (1, n_features)))
 
-    # check if the Hessian is positive-semidefinite via eigenvalues
     data = jax.random.normal(rng2, (n_features,))
 
-    # add batch dimension and compute the Hessian
-    hessian = jax.hessian(lambda x: model.apply(params, x[None]))(data)
+    # Compute Hessian of scalar output
+    hessian = jax.hessian(lambda x: model(x[None]).squeeze())(data)
 
-    # compute the Eigenvalues
     w = jnp.linalg.eigvalsh((hessian + hessian.T) / 2.0)
     np.testing.assert_array_equal(w >= 0, True)
+
+  def test_icnn_vector_output(self, rng: jax.Array):
+    """Tests ICNN with vector output (each component convex)."""
+    n_samples, n_features, output_dim = 10, 3, 4
+    dim_hidden = (32, 32)
+
+    model = icnn.ICNN(dim_hidden, output_dim=output_dim, rngs=nnx.Rngs(0))
+
+    x = jax.random.normal(rng, (n_samples, n_features))
+    out = model(x)
+    assert out.shape == (n_samples, output_dim)
+
+  def test_icnn_wx_inject_frequency(self, rng: jax.Array):
+    """Tests ICNN with wx_inject as frequency."""
+    n_features = 4
+    dim_hidden = (32, 32, 32, 32)
+
+    model = icnn.ICNN(dim_hidden, wx_inject=2, rngs=nnx.Rngs(0))
+    x = jax.random.normal(rng, (5, n_features))
+    out = model(x)
+    assert out.shape == (5,)
+
+  def test_icnn_pos_def_potentials(self, rng: jax.Array):
+    """Tests ICNN with PosDefPotentials enabled."""
+    n_features = 3
+    dim_hidden = (32, 32)
+
+    model = icnn.ICNN(dim_hidden, pos_def_rank=2, rngs=nnx.Rngs(0))
+    x = jax.random.normal(rng, (5, n_features))
+    out = model(x)
+    assert out.shape == (5,)
+
+  @pytest.mark.parametrize("mode", ["softmax", "sinkhorn"])
+  def test_icnn_stochastic_weights(self, rng: jax.Array, mode: str):
+    """Tests ICNN with softmax/sinkhorn weight normalization."""
+    n_samples, n_features = 10, 4
+    dim_hidden = (32, 32)
+
+    kwargs = {
+        "use_softmax": mode == "softmax",
+        "use_sinkhorn": mode == "sinkhorn",
+    }
+    model = icnn.ICNN(dim_hidden, rngs=nnx.Rngs(0), **kwargs)
+
+    rng1, rng2 = jax.random.split(rng)
+    x = jax.random.normal(rng1, (n_samples, n_features)) * 0.1
+    y = jax.random.normal(rng2, (n_samples, n_features))
+
+    out_x = model(x)
+    out_y = model(y)
+    assert out_x.shape == (n_samples,)
+
+    # Verify convexity
+    out = []
+    for t in jnp.linspace(0, 1):
+      out_xy = model(t * x + (1 - t) * y)
+      out.append((t * out_x + (1 - t) * out_y) - out_xy)
+
+    np.testing.assert_array_equal(np.array(out) >= -1e-5, True)
+
+
+@pytest.mark.fast()
+class TestKeyNet:
+
+  def test_keynet_output_shape(self, rng: jax.Array):
+    """Tests KeyNet output dimensions."""
+    n_samples, n_features = 10, 4
+    dim_hidden = (32, 32)
+
+    model = icnn.KeyNet(dim_hidden, rngs=nnx.Rngs(0))
+    x = jax.random.normal(rng, (n_samples, n_features))
+
+    # gradient returns vectors
+    grad_out = model.gradient(x)
+    assert grad_out.shape == (n_samples, n_features)
+
+    # __call__ returns scalars (dot product)
+    scalar_out = model(x)
+    assert scalar_out.shape == (n_samples,)
+
+  def test_keynet_resnet(self, rng: jax.Array):
+    """Tests KeyNet in resnet mode."""
+    n_features = 4
+    dim_hidden = (32, 32)
+
+    model = icnn.KeyNet(dim_hidden, resnet=True, rngs=nnx.Rngs(0))
+    x = jax.random.normal(rng, (5, n_features))
+
+    grad_out = model.gradient(x)
+    assert grad_out.shape == (5, n_features)
+
+  def test_keynet_custom_output_dim(self, rng: jax.Array):
+    """Tests KeyNet with explicit output_dim != input_dim."""
+    n_features = 4
+    output_dim = 8
+    dim_hidden = (32, 32)
+
+    model = icnn.KeyNet(dim_hidden, output_dim=output_dim, rngs=nnx.Rngs(0))
+    x = jax.random.normal(rng, (5, n_features))
+
+    grad_out = model.gradient(x)
+    assert grad_out.shape == (5, output_dim)
+
+  def test_keynet_unbatched(self, rng: jax.Array):
+    """Tests KeyNet with single (unbatched) input."""
+    n_features = 4
+    dim_hidden = (32, 32)
+
+    model = icnn.KeyNet(dim_hidden, rngs=nnx.Rngs(0))
+    x = jax.random.normal(rng, (n_features,))
+
+    grad_out = model.gradient(x)
+    assert grad_out.shape == (n_features,)
+
+    scalar_out = model(x)
+    assert scalar_out.shape == ()


### PR DESCRIPTION
Replace Flax Linen ICNN with NNX-based implementation. Key changes:

- PositiveDense: NNX module with softplus rectifier (default)
- PosDefPotentials: NNX module for optional quadratic terms
- ICNN: NNX module with flexible wx_inject, vector output support, optional PosDefPotentials (disabled by default)
- KeyNet: new vector-output network (ICNN-like without positive weight constraints), outputs gradients directly without autodiff