### PR TITLE
Add ICNN.gradient() method

### DIFF
--- a/src/ott/neural/networks/icnn.py
+++ b/src/ott/neural/networks/icnn.py
@@ -226,6 +226,23 @@ class ICNN(nnx.Module):
 
     return z.squeeze(0) if squeeze else z
 
+  def gradient(self, x: jax.Array) -> jax.Array:
+    """Gradient of the convex potential w.r.t. input.
+
+    For scalar output (``output_dim == 1``), returns the gradient.
+    For vector output, returns the Jacobian.
+
+    Args:
+      x: Input of shape ``[batch, input_dim]`` or ``[input_dim]``.
+
+    Returns:
+      Gradients of shape ``[batch, input_dim]`` (scalar output) or
+      ``[batch, output_dim, input_dim]`` (vector output).
+    """
+    if self._output_dim == 1:
+      return jax.vmap(jax.grad(self))(x)
+    return jax.vmap(jax.jacobian(self))(x)
+
   @property
   def is_potential(self) -> bool:
     """Whether this module represents a potential (True) or vector field."""


### PR DESCRIPTION
## Summary
- Add `ICNN.gradient(x)` method that computes the gradient of the convex potential w.r.t. input
- For scalar output (`output_dim=1`): returns shape `[batch, input_dim]` via `jax.grad`
- For vector output (`output_dim>1`): returns Jacobian shape `[batch, output_dim, input_dim]` via `jax.jacobian`

## Motivation
Useful for optimal transport maps where the transport is the gradient of a convex potential, and for downstream users (e.g., AMIPS) that need input gradients without writing boilerplate vmap/grad calls.

## Test plan
- [x] Tested locally with scalar and vector ICNN

🤖 Generated with [Claude Code](https://claude.com/claude-code)