### PR TITLE
fix: use submodule import for jax batching.is_vmappable

### DIFF
--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -35,7 +35,7 @@ except ImportError:
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax._src.interpreters import batching
+import jax._src.interpreters.batching as batching
 
 try:
   from tqdm import tqdm

--- a/src/ott/utils.py
+++ b/src/ott/utils.py
@@ -33,9 +33,9 @@ except ImportError:
   from typing_extensions import ParamSpec
 
 import jax
+import jax._src.interpreters.batching as batching
 import jax.numpy as jnp
 import numpy as np
-import jax._src.interpreters.batching as batching
 
 try:
   from tqdm import tqdm


### PR DESCRIPTION
## Problem

`batching.is_vmappable` was removed from the public JAX module in 0.9.0. The current import `from jax._src.interpreters import batching` resolves to the public module (which lacks `is_vmappable`) due to package-attribute shadowing.

Fixes #700

## Fix

Change the import to force the submodule binding:

```python
# Before (broken on JAX >= 0.9):
from jax._src.interpreters import batching

# After (works on all JAX versions):
import jax._src.interpreters.batching as batching
```

The `import ... as` form goes through `sys.modules` directly, bypassing the public module re-export that shadows the private submodule.

## Verification

```python
import jax._src.interpreters.batching as batching
print(hasattr(batching, 'is_vmappable'))  # True
```
